### PR TITLE
Bugfix/elastic net type

### DIFF
--- a/src/ports/postgres/modules/elastic_net/elastic_net.py_in
+++ b/src/ports/postgres/modules/elastic_net/elastic_net.py_in
@@ -302,10 +302,6 @@ def elastic_net_train(schema_madlib, tbl_source, tbl_result, col_dep_var,
                    SELECT {schema_madlib}.elastic_net_train('gaussian');
                    for supported optimizers.
                    """.format(schema_madlib=schema_madlib))
-
-    #keep a seperate copy of source table
-    plpy.execute(""" DROP TABLE IF EXISTS eln_tmp""")
-    plpy.execute(""" CREATE TABLE eln_tmp AS SELECT * FROM {source}""".format(source=tbl_source))
     # handle all special cases of col_ind_var
     col_ind_var, outstr_array = analyze_input_str(schema_madlib, tbl_source,
                                                   col_ind_var, col_dep_var,
@@ -335,20 +331,12 @@ def elastic_net_train(schema_madlib, tbl_source, tbl_result, col_dep_var,
                 schema_madlib, tbl_source, col_ind_var, col_dep_var,
                 tbl_result, lambda_value, alpha, standardize,
                 optimizer_params, max_iter, tolerance, outstr_array, **kwargs)
-            #restore the original table
-            plpy.execute(""" DROP TABLE IF EXISTS {source} """.format(source=tbl_source))
-            plpy.execute(""" CREATE TABLE {source} AS SELECT * FROM eln_tmp""".format(source=tbl_source))
-            plpy.execute(""" DROP TABLE IF EXISTS eln_tmp """)
             return None
         if optimizer.lower() == "fista":
             __elastic_net_gaussian_fista_train(
                 schema_madlib, tbl_source, col_ind_var, col_dep_var,
                 tbl_result, lambda_value, alpha, standardize,
                 optimizer_params, max_iter, tolerance, outstr_array, **kwargs)
-            #restore the original table
-            plpy.execute(""" DROP TABLE IF EXISTS {source} """.format(source=tbl_source))
-            plpy.execute(""" CREATE TABLE {source} AS SELECT * FROM eln_tmp""".format(source=tbl_source))
-            plpy.execute(""" DROP TABLE IF EXISTS eln_tmp """)
             return None
         not_supported_opt = True
     elif regress_family.lower() in ("binomial", "logistic"):
@@ -358,10 +346,6 @@ def elastic_net_train(schema_madlib, tbl_source, tbl_result, col_dep_var,
                 schema_madlib, tbl_source, col_ind_var, col_dep_var,
                 tbl_result, lambda_value, alpha, standardize,
                 optimizer_params, max_iter, tolerance, outstr_array, **kwargs)
-            #restore the original table
-            plpy.execute(""" DROP TABLE IF EXISTS {source} """.format(source=tbl_source))
-            plpy.execute(""" CREATE TABLE {source} AS SELECT * FROM eln_tmp""".format(source=tbl_source))
-            plpy.execute(""" DROP TABLE IF EXISTS eln_tmp """)
             return None
 
         if optimizer.lower() == "fista":
@@ -370,19 +354,11 @@ def elastic_net_train(schema_madlib, tbl_source, tbl_result, col_dep_var,
                 schema_madlib, tbl_source, col_ind_var, col_dep_var,
                 tbl_result, lambda_value, alpha, standardize,
                 optimizer_params, max_iter, tolerance, outstr_array, **kwargs)
-            #restore the original table
-            plpy.execute(""" DROP TABLE IF EXISTS {source} """.format(source=tbl_source))
-            plpy.execute(""" CREATE TABLE {source} AS SELECT * FROM eln_tmp""".format(source=tbl_source))
-            plpy.execute(""" DROP TABLE IF EXISTS eln_tmp """)
             return None
         not_supported_opt = True
     else:
         not_supported_family = True
     if not_supported_family or not_supported_opt:
-        #restore the original table
-        plpy.execute(""" DROP TABLE IF EXISTS {source} """.format(source=tbl_source))
-        plpy.execute(""" CREATE TABLE {source} AS SELECT * FROM eln_tmp""".format(source=tbl_source))
-        plpy.execute(""" DROP TABLE IF EXISTS eln_tmp """)
         plpy.error("""
                Elastic Net error: Not a supported response family or supported optimizer of the given response family!
                Run:
@@ -449,16 +425,6 @@ def analyze_input_str(schema_madlib, tbl_source,
                            Elastic Net error: All columns to be included in the
                            independent variables should be of the numeric type.
                            """)
-            elif not all(i == included_col_types[0]
-                        for i in included_col_types):
-                ## cast every column to float if needed
-                for i in range(len(outstr_array)):
-
-                    if included_col_types[i] != "double precision" :
-                        plpy.execute(""" ALTER TABLE {table2a}
-                                        ALTER COLUMN {col2a} TYPE float8
-                                        """.format(table2a=tbl_source ,col2a=outstr_array[i]))
-
         col_ind_var_new = "ARRAY[" + ','.join(outstr_array) + "]"
         return (col_ind_var_new, outstr_array)
 

--- a/src/ports/postgres/modules/elastic_net/elastic_net.py_in
+++ b/src/ports/postgres/modules/elastic_net/elastic_net.py_in
@@ -303,6 +303,9 @@ def elastic_net_train(schema_madlib, tbl_source, tbl_result, col_dep_var,
                    for supported optimizers.
                    """.format(schema_madlib=schema_madlib))
 
+    #keep a seperate copy of source table
+    plpy.execute(""" DROP TABLE IF EXISTS eln_tmp""")
+    plpy.execute(""" CREATE TABLE eln_tmp AS SELECT * FROM {source}""".format(source=tbl_source))
     # handle all special cases of col_ind_var
     col_ind_var, outstr_array = analyze_input_str(schema_madlib, tbl_source,
                                                   col_ind_var, col_dep_var,
@@ -332,12 +335,20 @@ def elastic_net_train(schema_madlib, tbl_source, tbl_result, col_dep_var,
                 schema_madlib, tbl_source, col_ind_var, col_dep_var,
                 tbl_result, lambda_value, alpha, standardize,
                 optimizer_params, max_iter, tolerance, outstr_array, **kwargs)
+            #restore the original table
+            plpy.execute(""" DROP TABLE IF EXISTS {source} """.format(source=tbl_source))
+            plpy.execute(""" CREATE TABLE {source} AS SELECT * FROM eln_tmp""".format(source=tbl_source))
+            plpy.execute(""" DROP TABLE IF EXISTS eln_tmp """)
             return None
         if optimizer.lower() == "fista":
             __elastic_net_gaussian_fista_train(
                 schema_madlib, tbl_source, col_ind_var, col_dep_var,
                 tbl_result, lambda_value, alpha, standardize,
                 optimizer_params, max_iter, tolerance, outstr_array, **kwargs)
+            #restore the original table
+            plpy.execute(""" DROP TABLE IF EXISTS {source} """.format(source=tbl_source))
+            plpy.execute(""" CREATE TABLE {source} AS SELECT * FROM eln_tmp""".format(source=tbl_source))
+            plpy.execute(""" DROP TABLE IF EXISTS eln_tmp """)
             return None
         not_supported_opt = True
     elif regress_family.lower() in ("binomial", "logistic"):
@@ -347,6 +358,10 @@ def elastic_net_train(schema_madlib, tbl_source, tbl_result, col_dep_var,
                 schema_madlib, tbl_source, col_ind_var, col_dep_var,
                 tbl_result, lambda_value, alpha, standardize,
                 optimizer_params, max_iter, tolerance, outstr_array, **kwargs)
+            #restore the original table
+            plpy.execute(""" DROP TABLE IF EXISTS {source} """.format(source=tbl_source))
+            plpy.execute(""" CREATE TABLE {source} AS SELECT * FROM eln_tmp""".format(source=tbl_source))
+            plpy.execute(""" DROP TABLE IF EXISTS eln_tmp """)
             return None
 
         if optimizer.lower() == "fista":
@@ -355,11 +370,19 @@ def elastic_net_train(schema_madlib, tbl_source, tbl_result, col_dep_var,
                 schema_madlib, tbl_source, col_ind_var, col_dep_var,
                 tbl_result, lambda_value, alpha, standardize,
                 optimizer_params, max_iter, tolerance, outstr_array, **kwargs)
+            #restore the original table
+            plpy.execute(""" DROP TABLE IF EXISTS {source} """.format(source=tbl_source))
+            plpy.execute(""" CREATE TABLE {source} AS SELECT * FROM eln_tmp""".format(source=tbl_source))
+            plpy.execute(""" DROP TABLE IF EXISTS eln_tmp """)
             return None
         not_supported_opt = True
     else:
         not_supported_family = True
     if not_supported_family or not_supported_opt:
+        #restore the original table
+        plpy.execute(""" DROP TABLE IF EXISTS {source} """.format(source=tbl_source))
+        plpy.execute(""" CREATE TABLE {source} AS SELECT * FROM eln_tmp""".format(source=tbl_source))
+        plpy.execute(""" DROP TABLE IF EXISTS eln_tmp """)
         plpy.error("""
                Elastic Net error: Not a supported response family or supported optimizer of the given response family!
                Run:
@@ -420,12 +443,21 @@ def analyze_input_str(schema_madlib, tbl_source,
                                             col_ind_var)
         else:
             included_col_types = [col_types_dict[i] for i in outstr_array]
-            if not all(i == included_col_types[0] and is_psql_numeric_type(i)
+            if not all(is_psql_numeric_type(i)
                        for i in included_col_types):
                 plpy.error("""
                            Elastic Net error: All columns to be included in the
-                           independent variables should be of the same numeric type.
+                           independent variables should be of the numeric type.
                            """)
+            elif not all(i == included_col_types[0]
+                        for i in included_col_types):
+                ## cast every column to float if needed
+                for i in range(len(outstr_array)):
+
+                    if included_col_types[i] != "double precision" :
+                        plpy.execute(""" ALTER TABLE {table2a}
+                                        ALTER COLUMN {col2a} TYPE float8
+                                        """.format(table2a=tbl_source ,col2a=outstr_array[i]))
 
         col_ind_var_new = "ARRAY[" + ','.join(outstr_array) + "]"
         return (col_ind_var_new, outstr_array)

--- a/src/ports/postgres/modules/elastic_net/elastic_net_optimizer_fista.py_in
+++ b/src/ports/postgres/modules/elastic_net/elastic_net_optimizer_fista.py_in
@@ -422,7 +422,7 @@ def __compute_fista(schema_madlib, func_step_aggregate, func_state_diff,
         arguments
     @param tbl_state Name of the (temporary) table containing the inter-iteration
         states
-    @param rel_source Name of the relation containing input points
+    @param tbl_source Name of the relation containing input points
     @param col_ind_var Name of the independent variables column
     @param col_dep_var Name of the dependent variable column
     @param drop_table Boolean, whether to use IterationController (True) or

--- a/src/ports/postgres/modules/elastic_net/test/elastic_net_install_check.sql_in
+++ b/src/ports/postgres/modules/elastic_net/test/elastic_net_install_check.sql_in
@@ -514,6 +514,16 @@ COPY lin_housing_wi (x, y) FROM STDIN NULL '?';
 {1,0.04741,0.00,11.930,0,0.5730,6.0300,80.80,2.5050,1,273.0,21.00,396.90,7.88}	11.90
 \.
 
+DROP TABLE IF EXISTS elastic_type_src;
+
+CREATE TABLE elastic_type_src ( var_int int, var_float8 float8, var_sint smallint);
+COPY elastic_type_src (var_int, var_float8, var_sint) FROM stdin DELIMITER ',' NULL '?' ;
+1, 1.1, 1
+2, 2.2, 2
+3, 3.3, 3
+4, 4.4, 4
+\.
+
 create function check_elastic_net ()
 returns void as $$
 begin
@@ -613,6 +623,23 @@ begin
     perform assert(relative_error(log_likelihood, -0.542468) < 1e-4,
         'Elastic Net: log-likelihood mismatch (use_active_set = t)!'
     ) from house_en;
+
+    execute 'DROP TABLE IF EXISTS elastic_type_res';
+    perform elastic_net_train('elastic_type_src',
+		'elastic_type_res',
+		'var_int < 0',
+		'*',
+		'binomial',
+		0.6,
+		0.02,
+		TRUE,
+		NULL,
+		'fista',
+		'',
+		'',
+		10000,
+		1e-6
+	);
 
 end;
 $$ language plpgsql volatile;


### PR DESCRIPTION
Summary: Type error in elastic net
JIRA: MADLIB-952
Columns were being checked to ensure every column has the same numeric type. While giving an error for non-numeric types is correct, there is no need to enforce same numeric type, as the columns are casted inside the function by default. The input analyzer is changed to relax this condition.