### PR TITLE
Term Freq: Allow custom col names, avoid temp vocab

### DIFF
--- a/src/ports/postgres/modules/utilities/text_utilities.py_in
+++ b/src/ports/postgres/modules/utilities/text_utilities.py_in
@@ -41,7 +41,7 @@ def _create_tf_table(input_table, doc_id_col, word_vec_col,
     word_type = 'INTEGER' if vocab_table else 'TEXT'
     word_name = 'wordid' if vocab_table else 'word'
     plpy.execute("""
-        CREATE TEMP TABLE {output_table}(
+        CREATE TABLE {output_table}(
             {doc_id_col} INTEGER,
             {word_name} {word_type},
             count INTEGER
@@ -72,7 +72,7 @@ def _create_tf_table(input_table, doc_id_col, word_vec_col,
                     WHERE
                         {doc_id_col} IS NOT NULL
                 ) q1
-                GROUP BY docid, word
+                GROUP BY {doc_id_col}, word
             ) q2
             {inner_query}
         """.format(**locals()))
@@ -80,7 +80,7 @@ def _create_tf_table(input_table, doc_id_col, word_vec_col,
 
 
 def term_frequency(input_table, doc_id_col, word_vec_col,
-                   output_table, compute_vocab=None):
+                   output_table, compute_vocab=False):
 
     input_tbl_valid(input_table, "Term frequency")
     output_tbl_valid(output_table, "Term frequency")

--- a/src/ports/postgres/modules/utilities/text_utilities.sql_in
+++ b/src/ports/postgres/modules/utilities/text_utilities.sql_in
@@ -97,9 +97,8 @@ INSERT INTO documents VALUES
 
 -# Add a new column containing the words (lower-cased) in a text array
 <pre class="example">
-ALTER TABLE documents DROP COLUMN words;
 ALTER TABLE documents ADD COLUMN words TEXT[];
-UPDATE documents SET words = regexp_split_to_array(lower(doc_contents), E'[\\s+\\.]');
+UPDATE documents SET words = regexp_split_to_array(lower(doc_contents), E'[\\\\s+\\\\.]');
 </pre>
 
 -# Compute the frequency of each word in each document


### PR DESCRIPTION
JIRA: MADLIB-933

- Fixed a minor bug that forced users to use "doc_id" as a column name.
- Fixed an incorrect temp table output for the vocabulary.

@mktal: Please review the PR and push to the apache remote after approval. 