### PR TITLE
PCA: Proportion of variance for PCA training function

### DIFF
--- a/src/ports/postgres/modules/linalg/svd.py_in
+++ b/src/ports/postgres/modules/linalg/svd.py_in
@@ -40,6 +40,73 @@ actual_lanczos_iterations = 0
 
 # ------------------------------------------------------------------------
 
+def svd(schema_madlib, source_table, output_table_prefix,
+        row_id, k, nIterations, result_summary_table=None):
+    """
+    Compute the Singular Value Decomposition of the matrix in source_table.
+
+    This function is the specific call for dense matrices and creates three
+    tables corresponding to the three decomposition matrices.
+
+    Args:
+        @param schema_madlib Schema where MADlib is installed
+        @param source_table Input table with the matrix to be decomposed
+                                (in sparse or dense format)
+        @param output_table_prefix    Prefix string for the output table names
+        @param row_id Name of the row_id column
+        @param k Number of eigen vectors to output
+        @param nIterations Number of iterations to run Lanczos algorithm
+                    (Higher the number, greater the accuracy, and
+                     greater the run time)
+        @param result_summary_table Name of the table to store summary of results
+    Returns:
+        None
+    """
+
+    if result_summary_table:
+        t0 = time.time()  # measure the starting time
+    old_msg_level = plpy.execute("select setting from pg_settings where \
+                                 name='client_min_messages'")[0]['setting']
+    plpy.execute("set client_min_messages to error")
+
+    _validate_args(schema_madlib, source_table, output_table_prefix,
+               k, row_id, nIterations, col_id=None, val_id=None,
+               result_summary_table=result_summary_table)
+    # Make sure that the input table has row_id and row_vec
+    # if not then make a copy of the source table and change column names
+    source_table_copy = "pg_temp." + unique_string() + "_2"
+    need_new_column_names = cast_dense_input_table_to_correct_columns(
+        schema_madlib, source_table, source_table_copy, row_id)
+
+    if(need_new_column_names):
+        source_table = source_table_copy
+
+    (new_source_table, bd_pref)=_svd_upper_wrap(schema_madlib, source_table,
+        output_table_prefix, row_id,k, nIterations, result_summary_table)
+
+    _svd_lower_wrap(schema_madlib, new_source_table, output_table_prefix,
+        row_id, k, nIterations, bd_pref)
+
+    if result_summary_table:
+
+        t1 = time.time()
+        [row_dim, col_dim] = get_dims(source_table,
+            {'row': 'row_id', 'col': 'col_id', 'val': 'row_vec'})
+        arguments = {'schema_madlib': schema_madlib,
+                     'source_table': source_table,
+                     'matrix_u': add_postfix(output_table_prefix, "_u"),
+                     'matrix_v': add_postfix(output_table_prefix, "_v"),
+                     'matrix_s': add_postfix(output_table_prefix, "_s"),
+                     'row_dim': row_dim,
+                     'col_dim': col_dim,
+                     'result_summary_table': result_summary_table,
+                     'temp_prefix': "pg_temp." + unique_string(),
+                     't0': t0, 't1': t1}
+        create_summary_table(**arguments)
+    plpy.execute("DROP TABLE if exists {0}".format(source_table_copy))
+    plpy.execute("set client_min_messages to " + old_msg_level)
+# ------------------------------------------------------------------------
+
 
 def _validate_args(schema_madlib, source_table, output_table_prefix, k,
                    row_id, nIterations, col_id=None, val_id=None,
@@ -116,7 +183,6 @@ def create_summary_table(**args):
     """ Summarize results from SVD in a summary table. """
     global actual_lanczos_iterations
     dt = (args['t1'] - args['t0']) * 1000.
-
     plpy.execute(
         """
         SELECT {schema_madlib}.matrix_mult(
@@ -125,7 +191,6 @@ def create_summary_table(**args):
             '{temp_prefix}_a', 'row=row_id, col=col_id, val=row_vec'
             );
         """.format(**args))
-
     plpy.execute(
         """
         SELECT {schema_madlib}.matrix_mult(
@@ -134,7 +199,6 @@ def create_summary_table(**args):
             '{temp_prefix}_b', 'row=row_id, col=col_id, val=row_vec'
             );
         """.format(**args))
-
     err = plpy.execute(
         """
         SELECT avg(s) / ({col_dim}::float8) as p
@@ -162,7 +226,6 @@ def create_summary_table(**args):
         ) Q1
         """.format(**args))[0]['p']
     relative_err = err / norm
-
     plpy.execute(
         """
         CREATE TABLE {result_summary_table} (rows_used INTEGER,
@@ -205,7 +268,7 @@ def svd_block(schema_madlib, source_table, output_table_prefix,
                                    'val': 'block'},
                                   is_block=True)
     if k > min(row_dim, col_dim):
-        plpy.error("SVD error: k cannot be larger than min(row_dim, col_dim) !")
+        plpy.error("SVD error: k cannot be larger than min(row_dim, col_dim)!")
 
     t0 = time.time()  # measure the starting time
 
@@ -221,7 +284,6 @@ def svd_block(schema_madlib, source_table, output_table_prefix,
             """.format(schema_madlib=schema_madlib,
                        source_table=source_table, x_trans=x_trans))
         _svd(schema_madlib, x_trans, output_table_prefix, k, nIterations, True)
-
         # Switch U and V
         _transpose_UV(schema_madlib,
                       add_postfix(output_table_prefix, "_u"),
@@ -431,50 +493,35 @@ def svd_sparse_native(schema_madlib, source_table, output_table_prefix,
 # ------------------------------------------------------------------------
 
 
-def svd(schema_madlib, source_table, output_table_prefix,
-        row_id, k, nIterations, result_summary_table=None):
+def _svd_upper_wrap(schema_madlib, source_table, output_table_prefix,
+        row_id, k, nIterations, result_summary_table):
     """
-    Compute the Singular Value Decomposition of the matrix in source_table.
+    Compute the Singular Value Decomposition of a sparse matrix
 
-    This function is the specific call for dense matrices and creates three
-    tables corresponding to the three decomposition matrices.
+    This function is the wrapper for the upper half of svd function.
+
+    Returns a tuple (new_source_table,bd_pref). new_source_table is returned
+    to be used in the lower part in case the table is transposed. bd_pref is a
+    tuple containing two table names, created with unique strings and required
+    in the lower half of svd
 
     Args:
         @param schema_madlib Schema where MADlib is installed
         @param source_table Input table with the matrix to be decomposed
-                                (in sparse or dense format)
         @param output_table_prefix    Prefix string for the output table names
         @param row_id Name of the row_id column
+        @param col_id Name of the col_id column
+        @param val    Name of the value column
         @param k Number of eigen vectors to output
         @param nIterations Number of iterations to run Lanczos algorithm
                     (Higher the number, greater the accuracy, and
                      greater the run time)
         @param result_summary_table Name of the table to store summary of results
     Returns:
-        None
+        (source_table,bd_pref)
     """
-    if result_summary_table:
-        t0 = time.time()  # measure the starting time
-
-    old_msg_level = plpy.execute("select setting from pg_settings where \
-                                 name='client_min_messages'")[0]['setting']
-    plpy.execute("set client_min_messages to error")
-
-    _validate_args(schema_madlib, source_table, output_table_prefix,
-                   k, row_id, nIterations, col_id=None, val_id=None,
-                   result_summary_table=result_summary_table)
-
-    # Make sure that the input table has row_id and row_vec
-    # if not then make a copy of the source table and change column names
-    source_table_copy = "pg_temp." + unique_string() + "_2"
-    need_new_column_names = cast_dense_input_table_to_correct_columns(
-        schema_madlib, source_table, source_table_copy, row_id)
-
-    if(need_new_column_names):
-        source_table = source_table_copy
-
     [row_dim, col_dim] = get_dims(source_table,
-                                  {'row': 'row_id', 'col': 'col_id', 'val': 'row_vec'})
+        {'row': 'row_id', 'col': 'col_id', 'val': 'row_vec'})
     validate_dense(source_table,
                    {'row': 'row_id', 'val': 'row_vec'},
                    check_col=False, row_dim=row_dim)
@@ -486,67 +533,50 @@ def svd(schema_madlib, source_table, output_table_prefix,
     # If the input matrix is a wide dense matrix(i.e. row_dim < col_dim),
     # We need to transpose it into a narrow one
     if col_dim > row_dim:
-        x_trans = "pg_temp." + unique_string() + "_3"
+        x_trans = "pg_temp." + unique_string() + "_xt_3"
         plpy.execute("""
             SELECT {schema_madlib}.matrix_trans(
                 '{source_table}', 'row=row_id, val=row_vec',
                 '{x_trans}', 'row=row_id, val=row_vec')
             """.format(schema_madlib=schema_madlib,
                        source_table=source_table, x_trans=x_trans))
-        _svd(schema_madlib, x_trans, output_table_prefix, k, nIterations, is_block=False)
+        bd_pref = _svd_upper(schema_madlib, x_trans, output_table_prefix, k, nIterations, is_block=False)
 
-        # Switch U and V
-        _transpose_UV(schema_madlib,
-                      add_postfix(output_table_prefix, "_u"),
-                      add_postfix(output_table_prefix, "_v"))
-        plpy.execute("DROP TABLE IF EXISTS {0}".format(x_trans))
+        return (x_trans,bd_pref)
+
     else:
-        _svd(schema_madlib, source_table, output_table_prefix, k, nIterations, is_block=False)
+        bd_pref = _svd_upper(schema_madlib, source_table, output_table_prefix, k, nIterations, is_block=False)
 
-    if result_summary_table:
-        t1 = time.time()
-        [row_dim, col_dim] = get_dims(source_table,
-                                      {'row': 'row_id', 'col': 'col_id', 'val': 'row_vec'})
-        arguments = {'schema_madlib': schema_madlib,
-                     'source_table': source_table,
-                     'matrix_u': add_postfix(output_table_prefix, "_u"),
-                     'matrix_v': add_postfix(output_table_prefix, "_v"),
-                     'matrix_s': add_postfix(output_table_prefix, "_s"),
-                     'row_dim': row_dim,
-                     'col_dim': col_dim,
-                     'result_summary_table': result_summary_table,
-                     'temp_prefix': "pg_temp." + unique_string(),
-                     't0': t0, 't1': t1}
-        create_summary_table(**arguments)
-
-    plpy.execute("DROP TABLE if exists {0}".format(source_table_copy))
-    plpy.execute("set client_min_messages to " + old_msg_level)
+    return (source_table, bd_pref)
 # ------------------------------------------------------------------------
 
 
-def _svd(schema_madlib, source_table, output_table_prefix,
+def _svd_upper(schema_madlib, source_table, output_table_prefix,
          k, nIterations, is_block=False,
          row_id=None, col_id=None, val=None):
-    """
-    Compute the SVD of a matrix (sparse or dense) into individual tables
 
-    The function computes SVD (USV') of a matrix using the Lanczos
-    Bidiagonalization method and stores the 'U' and 'V'
-    matrix as dense matrices and the 'S' matrix as a sparse matrix.
+    """
+    Compute the Singular Value Decomposition of a sparse matrix
+
+    This function is the upper half of svd function.
+
+    Returns a tuple (bidiagonal_prefix,svd_bidiagonal). Both of these table
+    names are created with unique strings and required in the lower half of svd
 
     Args:
         @param schema_madlib Schema where MADlib is installed
         @param source_table Input table with the matrix to be decomposed
-                                (in sparse or dense format)
         @param output_table_prefix    Prefix string for the output table names
-        @param k Number of eigen vectors to output
-        @param nIterations Number of iterations to run Lanczos algorithm
-                            (Higher the number, greater the accuracy, and
-                              greater the run time)
-        @param is_block Use block variant of matrix operations if True
         @param row_id Name of the row_id column
         @param col_id Name of the col_id column
-        @param val Name of the value column
+        @param val    Name of the value column
+        @param k Number of eigen vectors to output
+        @param nIterations Number of iterations to run Lanczos algorithm
+                    (Higher the number, greater the accuracy, and
+                     greater the run time)
+        @param result_summary_table Name of the table to store summary of results
+    Returns:
+        (bidiagonal_prefix,svd_bidiagonal)
     """
     nIterations_arg = (nIterations, "NULL")[nIterations is None]
     # Bidiagonalize the input matrix using the Lanczos algorithm
@@ -558,7 +588,6 @@ def _svd(schema_madlib, source_table, output_table_prefix,
         is_sparse = True
     else:
         is_sparse = False
-
     if is_sparse:
         plpy.execute("""
             SELECT {schema_madlib}.__svd_lanczos_bidiagonalize_sparse(
@@ -598,7 +627,8 @@ def _svd(schema_madlib, source_table, output_table_prefix,
         DROP TABLE IF EXISTS {svd_bidiagonal};
         CREATE TABLE {svd_bidiagonal} as
             SELECT {schema_madlib}.__svd_decompose_bidiag(
-                row_id::INTEGER[], col_id::INTEGER[], value::FLOAT8[]) AS svd_output
+                row_id::INTEGER[], col_id::INTEGER[],
+                value::FLOAT8[]) AS svd_output
             FROM {bidiagonal_prefix}_b;
         """.format(schema_madlib=schema_madlib,
                    svd_bidiagonal=svd_bidiagonal,
@@ -620,6 +650,7 @@ def _svd(schema_madlib, source_table, output_table_prefix,
         k = non_zero_svals
 
     # Compute the singular values and output to sparse table
+    # matrix_s_tmp = add_postfix(output_table_prefix, "_stmp")
     matrix_s = add_postfix(output_table_prefix, "_s")
     plpy.execute(
         """
@@ -635,14 +666,80 @@ def _svd(schema_madlib, source_table, output_table_prefix,
             ORDER BY row_id
             LIMIT {k}
         """.format(**locals()))
+    return (bidiagonal_prefix, svd_bidiagonal)
+# ------------------------------------------------------------------------
 
+
+def _svd_lower_wrap(schema_madlib, source_table, output_table_prefix,
+        row_id, k, nIterations, bd_pref, matrix_s=None):
+    """
+    Compute the Singular Value Decomposition of a sparse matrix
+
+    This function is the wrapper for the lower half of svd function.
+
+    Args:
+        @param schema_madlib Schema where MADlib is installed
+        @param source_table Input table with the matrix to be decomposed
+        @param output_table_prefix    Prefix string for the output table names
+        @param row_id Name of the row_id column
+        @param k Number of eigen vectors to output
+        @param nIterations Number of iterations to run Lanczos algorithm
+                    (Higher the number, greater the accuracy, and
+                     greater the run time)
+        @param bd_pref Tuple of table names related to the bidiagonalization
+    Returns:
+        None
+    """
+    _svd_lower(schema_madlib, source_table, output_table_prefix,
+        k, nIterations, bd_pref, False, None,None,None,matrix_s)
+
+    if "_xt_3" in source_table and "pg_temp." in source_table:
+
+        # Switch U and V
+        _transpose_UV(schema_madlib,
+                      add_postfix(output_table_prefix, "_u"),
+                      add_postfix(output_table_prefix, "_v"))
+        plpy.execute(
+            """DROP TABLE IF EXISTS {source_table}""".format(
+            source_table=source_table
+            ))
+    return None
+# ------------------------------------------------------------------------
+
+
+def _svd_lower(schema_madlib, source_table, output_table_prefix,
+         k, nIterations, bd_pref, is_block=False,
+         row_id=None, col_id=None, val=None, matrix_s=None):
+    """
+    Compute the Singular Value Decomposition of a sparse matrix
+
+    This function is the lower half of svd function.
+
+    Args:
+        @param schema_madlib Schema where MADlib is installed
+        @param source_table Input table with the matrix to be decomposed
+        @param output_table_prefix    Prefix string for the output table names
+        @param row_id Name of the row_id column
+        @param k Number of eigen vectors to output
+        @param nIterations Number of iterations to run Lanczos algorithm
+                    (Higher the number, greater the accuracy, and
+                     greater the run time)
+        @param bd_pref Tuple of table names related to the bidiagonalization
+    Returns:
+        None
+    """
+    # Compute the singular values and output to sparse table
+    if matrix_s is None:
+        matrix_s = add_postfix(output_table_prefix, "_s")
+
+    bidiagonal_prefix = bd_pref[0]
+    svd_bidiagonal = bd_pref[1]
     plpy.execute("""
         INSERT INTO {matrix_s}
         SELECT {k}, {k}, NULL
         FROM {svd_bidiagonal}
         LIMIT 1
         """.format(**locals()))
-
     # Compute the left singular matrix and output to table
     plpy.execute("""
         SELECT
@@ -675,6 +772,8 @@ def _svd(schema_madlib, source_table, output_table_prefix,
                    svd_bidiagonal=svd_bidiagonal,
                    k=k))
 
+    #plpy.execute("DROP TABLE if exists {matrix_s_tmp}"
+    #             .format(matrix_s_tmp=matrix_s_tmp))
     plpy.execute("DROP TABLE if exists {svd_bidiagonal}"
                  .format(svd_bidiagonal=svd_bidiagonal))
     plpy.execute("""
@@ -684,6 +783,38 @@ def _svd(schema_madlib, source_table, output_table_prefix,
                  """.format(bidiagonal_prefix=bidiagonal_prefix))
 
     return None
+# ------------------------------------------------------------------------
+
+
+def _svd(schema_madlib, source_table, output_table_prefix,
+         k, nIterations, is_block=False,
+         row_id=None, col_id=None, val=None):
+    """
+    Compute the SVD of a matrix (sparse or dense) into individual tables
+
+    The function computes SVD (USV') of a matrix using the Lanczos
+    Bidiagonalization method and stores the 'U' and 'V'
+    matrix as dense matrices and the 'S' matrix as a sparse matrix.
+
+    Args:
+        @param schema_madlib Schema where MADlib is installed
+        @param source_table Input table with the matrix to be decomposed
+                                (in sparse or dense format)
+        @param output_table_prefix    Prefix string for the output table names
+        @param k Number of eigen vectors to output
+        @param nIterations Number of iterations to run Lanczos algorithm
+                            (Higher the number, greater the accuracy, and
+                              greater the run time)
+        @param is_block Use block variant of matrix operations if True
+        @param row_id Name of the row_id column
+        @param col_id Name of the col_id column
+        @param val Name of the value column
+    """
+    bd_pref = _svd_upper(schema_madlib, source_table, output_table_prefix, k,
+         nIterations, is_block, row_id, col_id, val)
+
+    _svd_lower(schema_madlib, source_table, output_table_prefix, k,
+         nIterations, bd_pref, is_block, row_id, col_id, val)
 # ------------------------------------------------------------------------
 
 
@@ -789,8 +920,6 @@ def _lanczos_bidiagonalize_output_results(schema_madlib, output_table_prefix,
         ) t
         """.format(output_table_prefix=output_table_prefix,
                    pq_table_prefix=pq_table_prefix, k=k))
-
-
 # ------------------------------------------------------------------------
 
 

--- a/src/ports/postgres/modules/pca/pca.py_in
+++ b/src/ports/postgres/modules/pca/pca.py_in
@@ -17,6 +17,9 @@ from utilities.utilities import unique_string
 from utilities.utilities import _assert
 from utilities.validate_args import columns_exist_in_table
 from utilities.validate_args import table_exists
+from linalg.svd import create_summary_table
+from linalg.svd import _svd_upper_wrap
+from linalg.svd import _svd_lower_wrap
 
 import time
 import plpy
@@ -25,7 +28,284 @@ version_wrapper = __mad_version()
 string_to_array = version_wrapper.select_vecfunc()
 array_to_string = version_wrapper.select_vec_return()
 
+# ========================================================================
+def pca(schema_madlib, source_table, pc_table, row_id,
+        k, grouping_cols, lanczos_iter, use_correlation,
+        result_summary_table, variance, **kwargs):
+    """
+    Compute the PCA of the matrix in source_table.
 
+    This function is the specific call for dense matrices and creates three
+    tables corresponding to the three decomposition matrices.
+
+    Args:
+        @param schema_madlib
+        @param source_table
+        @param pc_table
+        @param row_id
+        @param k
+        @param grouping_cols
+        @param lanczos_iter
+        @param use_correlation
+        @param result_summary_table
+        @param variance
+
+    Returns:
+        None
+
+    """
+    startTime = time.time()  # measure the starting time
+    # Reset the message level to avoid random messages
+    old_msg_level = plpy.execute("""
+                                  SELECT setting
+                                  FROM pg_settings
+                                  WHERE name='client_min_messages'
+                                  """)[0]['setting']
+    plpy.execute('SET client_min_messages TO warning')
+
+    # Step 1: Validate the input arguments
+    _validate_args(schema_madlib, source_table, pc_table, k,
+                   row_id, None, None, None, None,
+                   grouping_cols, lanczos_iter, use_correlation,
+                   result_summary_table,variance)
+
+    # Make sure that the table has row_id and row_vec
+    source_table_copy = "pg_temp." + unique_string() + "_reformated_names"
+    created_new_table = cast_dense_input_table_to_correct_columns(
+        schema_madlib, source_table, source_table_copy, row_id)
+
+    if(created_new_table):
+        source_table = source_table_copy
+
+    [row_dim, col_dim] = get_dims(source_table,
+                                  {'row': 'row_id', 'col': 'col_id',
+                                   'val': 'row_vec'})
+    validate_dense(source_table,
+                   {'row': 'row_id', 'val': 'row_vec'},
+                   check_col=False, row_dim=row_dim)
+    if k:
+        if k > min(row_dim, col_dim):
+            plpy.error(
+                "PCA error: k cannot be larger than min(row_dim, col_dim)!")
+        curK = k
+    else:
+        curK = min(row_dim,col_dim)
+    # If using the default number of lanczos iterations, set to the default
+    if lanczos_iter == 0:
+        if k:
+            lanczos_iter = min(k + 40, min(col_dim, row_dim))
+        else:
+            lanczos_iter = min(col_dim, row_dim)
+    else:
+        if variance: #lanczos_iter overrides the proportion default for k
+            curK = lanczos_iter
+
+    # Note: we currently don't support grouping columns or correlation matrices
+    if grouping_cols is None and not use_correlation:
+
+        # Step 2: Normalize the data (Column means)
+        dimension = col_dim
+        scaled_source_table = "pg_temp." + unique_string() + "_scaled_table"
+        column_mean_str = _recenter_data(schema_madlib,
+                                         source_table,
+                                         scaled_source_table,
+                                         'row_id',
+                                         'row_vec',
+                                         dimension)
+        # Step 3: Create temporary output & result summary table
+        svd_output_temp_table = "pg_temp."+ unique_string()+ "_svd_out_tbl"
+
+        if result_summary_table is None:
+            result_summary_table_string = ''
+        else:
+            result_summary_table_string = ", '{0}'".format(result_summary_table)
+
+        # Step 4: Perform SVD
+        # Step 4.1: Perform upper part of SVD
+        if result_summary_table:
+            t0 = time.time()
+
+        (source_table_svd,bd_pref) = _svd_upper_wrap(schema_madlib,
+            scaled_source_table, svd_output_temp_table,
+            row_id, curK, lanczos_iter, result_summary_table)
+
+        # Calculate the sum of values for proportion
+        svd_var_s = add_postfix(svd_output_temp_table, "_s")
+        eigen_sum=plpy.execute(
+            """
+            SELECT {schema_madlib}.array_sum(
+                {schema_madlib}.sum(
+                    {schema_madlib}.array_square(row_vec)
+                )
+            )
+            FROM {scaled_source_table}
+            """.format(**locals()))[0]['array_sum']
+
+        # Step 4.2: Adjust the k value
+        if variance:
+            variance_tmp_table = "pg_temp."+ unique_string()+ "_var_tmp"
+            plpy.execute(
+                """
+                CREATE TABLE {variance_tmp_table} AS
+                (SELECT row_id, col_id, sum(value*value)
+                    OVER(ORDER BY value DESC)
+                    FROM {svd_var_s})
+                """.format(variance_tmp_table=variance_tmp_table,
+                    svd_var_s=svd_var_s))
+            ecount = plpy.execute("""
+                SELECT count(sum) FROM {variance_tmp_table}
+                    WHERE sum/{eigen_sum} < {variance}
+                """.format(variance_tmp_table=variance_tmp_table,
+                    eigen_sum=eigen_sum, variance=variance))
+            curK = ecount[0]['count']
+            # The next value is the first that is over the treshold
+            if (lanczos_iter > curK):
+                curK = curK+1
+            plpy.execute("""
+                DROP TABLE IF EXISTS {variance_tmp_table}
+                """.format(variance_tmp_table=variance_tmp_table))
+
+        # Step 4.3: Perform the lower part of SVD
+        tmp_matrix_table = "temp_"+ unique_string()+ "_matrix"
+        tmp_matrix_s_table = add_postfix(tmp_matrix_table, "_s")
+
+        if variance: #remove elements after the variance threshold
+            plpy.execute(
+                """
+                m4_ifdef(`__HAWQ__',
+                    `
+                    CREATE TABLE {tmp_matrix_s_table} AS
+                    SELECT * FROM {svd_var_s} WHERE row_id-1 < {curK};
+                    DROP TABLE IF EXISTS {svd_var_s};
+                    ',
+                    `
+                    DELETE FROM {svd_var_s}
+                    WHERE row_id >{curK};
+                    ALTER TABLE {svd_var_s} RENAME TO {tmp_matrix_s_table};
+                    ')
+                    """.format(**locals())
+            )
+            _svd_lower_wrap(schema_madlib, source_table_svd,
+                svd_output_temp_table, row_id, curK, lanczos_iter, bd_pref,
+                tmp_matrix_s_table)
+        else:
+            tmp_matrix_table = svd_output_temp_table
+            _svd_lower_wrap(schema_madlib, source_table_svd,
+                svd_output_temp_table, row_id, curK, lanczos_iter, bd_pref)
+
+        # Step 4.4: Create the SVD result table
+        if result_summary_table:
+            t1 = time.time()
+            [row_dim, col_dim] = get_dims(source_table,
+                {'row': 'row_id', 'col': 'col_id', 'val': 'row_vec'})
+            arguments = {'schema_madlib': schema_madlib,
+                         'source_table': scaled_source_table,
+                         'matrix_u': add_postfix(svd_output_temp_table, "_u"),
+                         'matrix_v': add_postfix(svd_output_temp_table, "_v"),
+                         'matrix_s': add_postfix(tmp_matrix_table, "_s"),
+                         'row_dim': row_dim,
+                         'col_dim': col_dim,
+                         'result_summary_table': result_summary_table,
+                         'temp_prefix': "pg_temp." + unique_string(),
+                         't0': t0, 't1': t1}
+            create_summary_table(**arguments)
+        # Step 5: Transpose SVD output matrix
+        svd_v_transpose = "pg_temp." + unique_string() + "transpose"
+
+        svd_output_temp_table_s = add_postfix(tmp_matrix_table, "_s")
+        svd_output_temp_table_v = add_postfix(svd_output_temp_table, "_v")
+        svd_output_temp_table_u = add_postfix(svd_output_temp_table, "_u")
+        plpy.execute(
+            """
+            SELECT  {schema_madlib}.matrix_trans(
+                    '{svd_output_temp_table_v}',
+                    'row=row_id, col=col_id, val=row_vec',
+                    '{svd_v_transpose}', 'row=row_id, col=col_id, val=row_vec');
+            """.format(svd_output_temp_table_v=svd_output_temp_table_v,
+                       svd_v_transpose=svd_v_transpose,
+                       schema_madlib=schema_madlib)
+        )
+        # Step 6: Insert the output of SVD into the PCA table
+        plpy.execute(
+            """
+            CREATE TABLE {pc_table} AS
+            SELECT  {svd_v_transpose}.row_id,
+                    row_vec AS principal_components,
+                    value / sqrt({row_dim} - 1) AS std_dev,
+                    ((value*value)/ {eigen_sum}) AS proportion
+            FROM {svd_v_transpose},
+                 {svd_output_temp_table_s}
+            WHERE ({svd_v_transpose}.row_id = {svd_output_temp_table_s}.row_id)
+                  AND ({svd_v_transpose}.row_id <= {k})
+                  AND value is not NULL
+            """.format(svd_output_temp_table_s=svd_output_temp_table_s,
+                       k=curK,
+                       svd_v_transpose=svd_v_transpose,
+                       pc_table=pc_table,
+                       row_dim=row_dim,
+                       eigen_sum=eigen_sum))
+        # Output the column mean
+        pc_table_mean = add_postfix(pc_table, "_mean")
+        plpy.execute(
+            """
+            DROP TABLE IF EXISTS {pc_table_mean};
+            CREATE TABLE {pc_table_mean} AS
+            SELECT '{column_mean_str}'::FLOAT8[] AS column_mean
+            """.format(pc_table_mean=pc_table_mean,
+                       column_mean_str=column_mean_str))
+        # Step 7: Append to the SVD summary table to get the PCA summary table
+        if result_summary_table:
+            stopTime = time.time()
+            dt = (stopTime - startTime) * 1000.
+            summary_table_tmp_name = unique_string()
+            plpy.execute(
+                """
+                ALTER TABLE {result_summary_table}
+                RENAME TO {tmp_name};
+                """.format(result_summary_table=result_summary_table,
+                           tmp_name=summary_table_tmp_name))
+            plpy.execute(
+                """
+                CREATE TABLE {result_summary_table} AS
+                SELECT
+                    rows_used,
+                    {dt} AS "exec_time (ms)",
+                    {iter} AS iter,
+                    recon_error,
+                    relative_recon_error,
+                    {use_correlation} AS use_correlation
+                FROM {tmp_name};
+                """.format(result_summary_table=result_summary_table,
+                           dt=str(dt), iter=curK,
+                           use_correlation=bool(use_correlation),
+                           tmp_name=summary_table_tmp_name))
+            plpy.execute("DROP TABLE {tmp_name};".format(
+                tmp_name=summary_table_tmp_name))
+
+        # Step 8: Output handling & cleanup
+        plpy.execute(
+            """
+            DROP TABLE IF EXISTS {tmp_matrix_s_table};
+            DROP TABLE IF EXISTS {svd_v_transpose};
+            DROP TABLE IF EXISTS {source_table_copy};
+            DROP TABLE IF EXISTS {svd_output_temp_table};
+            DROP TABLE IF EXISTS {svd_output_temp_table_s};
+            DROP TABLE IF EXISTS {svd_output_temp_table_u};
+            DROP TABLE IF EXISTS {svd_output_temp_table_v};
+            DROP TABLE IF EXISTS {scaled_source_table};
+            """.format(svd_output_temp_table=svd_output_temp_table,
+                       svd_output_temp_table_s=svd_output_temp_table_s,
+                       svd_output_temp_table_u=svd_output_temp_table_u,
+                       svd_output_temp_table_v=svd_output_temp_table_v,
+                       scaled_source_table=scaled_source_table,
+                       svd_v_transpose=svd_v_transpose,
+                       source_table_copy=source_table_copy,
+                       tmp_matrix_s_table=tmp_matrix_s_table))
+
+    plpy.execute("SET client_min_messages TO %s" % old_msg_level)
+# ------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------
 # Validate arguments: Same as pca
 # ------------------------------------------------------------------------
 def _validate_args(schema_madlib,
@@ -40,7 +320,8 @@ def _validate_args(schema_madlib,
                    grouping_cols=None,
                    lanczos_iter=0,
                    use_correlation=False,
-                   result_summary_table=None):
+                   result_summary_table=None,
+                   variance=None):
     """
     Validates all arguments passed to the PCA function
     Args:
@@ -55,6 +336,7 @@ def _validate_args(schema_madlib,
         @param lanczos_iter     The number of lanczos iterations to use in the SVD calculation
         @param use_correlation  If the correlation matrix should be used instead of the covariance matrix
         @param result_summary_table  Name of summary table
+        @param variance         Proportion of variance
 
     Returns:
         None
@@ -66,10 +348,15 @@ def _validate_args(schema_madlib,
     _assert(source_table is not None and table_exists(source_table),
             "PCA error: Source data table {0} does not exist!".
             format(str(source_table)))
-
-    if k <= 0:
-        plpy.error("PCA error: k must be a positive integer!")
-
+    if not k and not variance:
+        plpy.error("PCA error: components_param must be valid!")
+    if k:
+        if k <= 0:
+            plpy.error("PCA error: k must be a positive integer!")
+    if variance:
+        if (variance <= 0) or (variance >=1):
+            plpy.error(
+                "PCA error: proportion of variance has to be between 0 and 1")
     # confirm output tables are valid
     if pc_table:
         _assert(not table_exists(pc_table, only_first_schema=True) and
@@ -200,6 +487,7 @@ def pca_sparse(schema_madlib,
                lanczos_iter,
                use_correlation,
                result_summary_table,
+               variance,
                **kwargs):
     """
     Compute the PCA of a sparse matrix in source_table.
@@ -221,6 +509,7 @@ def pca_sparse(schema_madlib,
         @param lanczos_iter
         @param use_correlation
         @param result_summary_table
+        @param variance
 
     Returns:
         None
@@ -238,7 +527,7 @@ def pca_sparse(schema_madlib,
     # Step 1: Validate the input arguments
     _validate_args(schema_madlib, source_table, pc_table, k, row_id, col_id,
                    val_id, row_dim, col_dim, grouping_cols, lanczos_iter,
-                   use_correlation, result_summary_table)
+                   use_correlation, result_summary_table, variance)
 
     # Step 2: Densify the matrix
     #  We densify the matrix because the recentering process will generate a
@@ -263,7 +552,7 @@ def pca_sparse(schema_madlib,
     # Step 3: Pass the densified matrix to regular PCA
     pca(schema_madlib, x_dense, pc_table, 'row_id',
         k, grouping_cols, lanczos_iter, use_correlation,
-        result_summary_table)
+        result_summary_table, variance)
 
     # Step 4: Clean up
     plpy.execute("""
@@ -301,194 +590,6 @@ def pca_sparse(schema_madlib,
 # ------------------------------------------------------------------------
 
 
-def pca(schema_madlib, source_table, pc_table, row_id,
-        k, grouping_cols, lanczos_iter, use_correlation,
-        result_summary_table,
-        **kwargs):
-    """
-    Compute the PCA of the matrix in source_table.
-
-    This function is the specific call for dense matrices and creates three
-    tables corresponding to the three decomposition matrices.
-
-    Args:
-        @param schema_madlib
-        @param source_table
-        @param pc_table
-        @param row_id
-        @param k
-        @param grouping_cols
-        @param lanczos_iter
-        @param use_correlation
-        @param result_summary_table
-
-    Returns:
-        None
-
-    """
-    startTime = time.time()
-
-    # Reset the message level to avoid random messages
-    old_msg_level = plpy.execute("""
-                                  SELECT setting
-                                  FROM pg_settings
-                                  WHERE name='client_min_messages'
-                                  """)[0]['setting']
-    plpy.execute('SET client_min_messages TO warning')
-
-    # Step 1: Validate the input arguments
-    _validate_args(schema_madlib, source_table, pc_table, k,
-                   row_id, None, None, None, None,
-                   grouping_cols, lanczos_iter, use_correlation,
-                   result_summary_table)
-
-    # Make sure that the table has row_id and row_vec
-    source_table_copy = "pg_temp." + unique_string() + "_reformated_names"
-    created_new_table = cast_dense_input_table_to_correct_columns(
-        schema_madlib, source_table, source_table_copy, row_id)
-
-    if(created_new_table):
-        source_table = source_table_copy
-
-    [row_dim, col_dim] = get_dims(source_table,
-                                  {'row': 'row_id', 'col': 'col_id',
-                                   'val': 'row_vec'})
-    validate_dense(source_table,
-                   {'row': 'row_id', 'val': 'row_vec'},
-                   check_col=False, row_dim=row_dim)
-
-    # If using the default number of lanczos iterations, set to the default
-    if lanczos_iter == 0:
-        lanczos_iter = min(k + 40, min(col_dim, row_dim))
-
-    # Note: we currently don't support grouping columns or correlation matrices
-    if grouping_cols is None and not use_correlation:
-
-        # Step 2: Normalize the data (Column means)
-        dimension = col_dim
-        scaled_source_table = "pg_temp." + unique_string() + "_scaled_table"
-        column_mean_str = _recenter_data(schema_madlib,
-                                         source_table,
-                                         scaled_source_table,
-                                         'row_id',
-                                         'row_vec',
-                                         dimension)
-
-        # Step 3: Create temporary output & result summary table
-        svd_output_temp_table = "pg_temp." + unique_string() + "_svd_output_table"
-
-        if result_summary_table is None:
-            result_summary_table_string = ''
-        else:
-            result_summary_table_string = ", '{0}'".format(result_summary_table)
-
-        # Step 4: Perform SVD
-        plpy.execute(
-            """
-            SELECT {schema_madlib}.svd('{scaled_source_table}',
-                                       '{svd_output_temp_table}',
-                                       'row_id',
-                                       {k},
-                                       {lanczos_iter}
-                                       {result_summary_table_string})
-            """.format(schema_madlib=schema_madlib,
-                       scaled_source_table=scaled_source_table,
-                       svd_output_temp_table=svd_output_temp_table,
-                       k=k,
-                       lanczos_iter=lanczos_iter,
-                       result_summary_table_string=result_summary_table_string))
-        # Step 5: Transpose SVD output matrix
-        svd_v_transpose = "pg_temp." + unique_string() + "transpose"
-        svd_output_temp_table_s = add_postfix(svd_output_temp_table, "_s")
-        svd_output_temp_table_v = add_postfix(svd_output_temp_table, "_v")
-        svd_output_temp_table_u = add_postfix(svd_output_temp_table, "_u")
-        plpy.execute(
-            """
-            SELECT  {schema_madlib}.matrix_trans(
-                    '{svd_output_temp_table_v}',
-                    'row=row_id, col=col_id, val=row_vec',
-                    '{svd_v_transpose}', 'row=row_id, col=col_id, val=row_vec');
-            """.format(svd_output_temp_table_v=svd_output_temp_table_v,
-                       svd_v_transpose=svd_v_transpose,
-                       schema_madlib=schema_madlib)
-        )
-
-        # Step 6: Insert the output of SVD into the PCA table
-        plpy.execute(
-            """
-            CREATE TABLE {pc_table} as
-            SELECT  {svd_v_transpose}.row_id,
-                    row_vec AS principal_components,
-                    value / sqrt({row_dim} - 1) AS eigen_values
-            FROM {svd_v_transpose},
-                 {svd_output_temp_table_s}
-            WHERE ({svd_v_transpose}.row_id = {svd_output_temp_table_s}.row_id)
-                  AND ({svd_v_transpose}.row_id <= {k})
-                  AND value is not NULL
-            """.format(svd_output_temp_table_s=svd_output_temp_table_s,
-                       k=k,
-                       svd_v_transpose=svd_v_transpose,
-                       pc_table=pc_table,
-                       row_dim=row_dim))
-        # Output the column mean
-        pc_table_mean = add_postfix(pc_table, "_mean")
-        plpy.execute(
-            """
-            DROP TABLE IF EXISTS {pc_table_mean};
-            CREATE TABLE {pc_table_mean} AS
-            SELECT '{column_mean_str}'::FLOAT8[] AS column_mean
-            """.format(pc_table_mean=pc_table_mean,
-                       column_mean_str=column_mean_str))
-
-        # Step 7: Append to the SVD summary table to get the PCA summary table
-        if result_summary_table:
-            stopTime = time.time()
-            dt = (stopTime - startTime) * 1000.
-            summary_table_tmp_name = unique_string()
-            plpy.execute(
-                """
-                ALTER TABLE {result_summary_table}
-                RENAME TO {tmp_name};
-                """.format(result_summary_table=result_summary_table,
-                           tmp_name=summary_table_tmp_name))
-            plpy.execute(
-                """
-                CREATE TABLE {result_summary_table} AS
-                SELECT
-                    rows_used,
-                    {dt} AS "exec_time (ms)",
-                    iter,
-                    recon_error,
-                    relative_recon_error,
-                    {use_correlation} AS use_correlation
-                FROM {tmp_name};
-                """.format(result_summary_table=result_summary_table,
-                           dt=str(dt), use_correlation=bool(use_correlation),
-                           tmp_name=summary_table_tmp_name))
-            plpy.execute("DROP TABLE {tmp_name};".format(
-                tmp_name=summary_table_tmp_name))
-
-        # Step 8: Output handling & cleanup
-        plpy.execute(
-            """
-            DROP TABLE IF EXISTS {svd_v_transpose};
-            DROP TABLE IF EXISTS {source_table_copy};
-            DROP TABLE IF EXISTS {svd_output_temp_table};
-            DROP TABLE IF EXISTS {svd_output_temp_table_s};
-            DROP TABLE IF EXISTS {svd_output_temp_table_u};
-            DROP TABLE IF EXISTS {svd_output_temp_table_v};
-            DROP TABLE IF EXISTS {scaled_source_table};
-            """.format(svd_output_temp_table=svd_output_temp_table,
-                       svd_output_temp_table_s=svd_output_temp_table_s,
-                       svd_output_temp_table_u=svd_output_temp_table_u,
-                       svd_output_temp_table_v=svd_output_temp_table_v,
-                       scaled_source_table=scaled_source_table,
-                       svd_v_transpose=svd_v_transpose,
-                       source_table_copy=source_table_copy))
-
-    plpy.execute("SET client_min_messages TO %s" % old_msg_level)
-
-
 def pca_sparse_help_message(schema_madlib, message=None, **kwargs):
     """
     Given a help string, provide usage information
@@ -514,7 +615,7 @@ def pca_sparse_help_message(schema_madlib, message=None, **kwargs):
             val_id              -- TEXT,    Column name for the sparse values.
             row_dim,            -- INTEGER, The number of rows in the sparse matrix
             col_dim,            -- INTEGER, The number of columns in the sparse matrix
-            k                   -- INTEGER, Number of principal components to compute
+            components_param    -- INTEGER OR FLOAT, The parameter to control the number of principal components to calculate from the input data.
             [
             grouping_cols       -- TEXT,    Comma-separated list of grouping columns
                                             (Default: NULL)
@@ -527,6 +628,8 @@ def pca_sparse_help_message(schema_madlib, message=None, **kwargs):
                                             (Default: NULL)
             ]
         );
+        If components_param is INTEGER it is used for denoting the number of principal components to compute.
+        If components_param is FLOAT it is used as the target proportion of variance.
         -------------------------------------------------------------------------
                                 OUTPUT TABLES
         -------------------------------------------------------------------------
@@ -587,7 +690,7 @@ def pca_help_message(schema_madlib, message=None, **kwargs):
             source_table        -- TEXT,    Name of data table
             pc_table            -- TEXT,    Name of the table containing the principle components
             row_id              -- TEXT,    Column name for the row coordinates.
-            k                   -- INTEGER, Number of principal components to compute
+            components_param    -- INTEGER OR FLOAT, The parameter to control the number of principal components to calculate from the input data.
             [
             grouping_cols       -- TEXT,    Comma-separated list of grouping columns
                                             (Default: NULL)
@@ -598,8 +701,12 @@ def pca_help_message(schema_madlib, message=None, **kwargs):
                                             (Default: False)
             rslt_summary_table  -- TEXT,    Table name to store summary of results
                                             (Default: NULL)
+            variance            -- DOUBLE PRECISION, Proportion of variance
+                                            (Default: NULL)
             ]
         );
+        If components_param is INTEGER it is used for denoting the number of principal components to compute.
+        If components_param is FLOAT it is used as the target proportion of variance.
         -------------------------------------------------------------------------
                                 OUTPUT TABLES
         -------------------------------------------------------------------------

--- a/src/ports/postgres/modules/pca/pca.sql_in
+++ b/src/ports/postgres/modules/pca/pca.sql_in
@@ -50,7 +50,7 @@ The training functions have the following formats:
 pca_train( source_table,
            out_table,
            row_id,
-           k,
+           components_param,
            grouping_cols,
            lanczos_iter,
            use_correlation,
@@ -66,7 +66,7 @@ pca_sparse_train( source_table,
                   val_id,
                   row_dim,
                   col_dim,
-                  k,
+                  components_param,
                   grouping_cols,
                   lanczos_iter,
                   use_correlation,
@@ -118,10 +118,13 @@ of the nonzero entries.
 </DD>
 
 <DT>out_table</DT>
-<DD>TEXT. The name of the table that will contain the output. The output is divided into three tables.
+<DD>TEXT. The name of the table that will contain the output. 
+The output is divided into three tables.
 
-The primary output table (<em>out_table</em>) encodes the principal components with the
-<em>k</em> highest eigenvalues. The table has the following columns:
+The primary output table (<em>out_table</em>) encodes the principal components 
+with the <em>k</em> highest eigenvalues where <em>k</em> is either directly 
+provided by the user or computed according to the proportion of variance. 
+The table has the following columns:
 <table class="output">
 <tr>
 <th>row_id</th>
@@ -132,8 +135,12 @@ The primary output table (<em>out_table</em>) encodes the principal components w
 <td>Vectors containing elements of the principal components.</td>
 </tr>
 <tr>
-<th>eigen_values</th>
-<td>The eigenvalues associated with each principal component.</td>
+<th>std_dev</th>
+<td>The standart deviation of each principal component.</td>
+</tr>
+<tr>
+<th>proportion</th>
+<td>The proportion of variance covered by the principal component.</td>
 </tr>
 </table>
 
@@ -168,8 +175,13 @@ contain values between 1 and <em>M</em>.</DD>
 <DT>col_dim</DT>
 <DD>INTEGER.  The number of columns in the sparse matrix (sparse matrices only). </DD>
 
-<DT>k</DT>
-<DD>INTEGER.  The number of principal components to calculate from the input data.  </DD>
+<DT>components_param</DT>
+<DD>INTEGER or FLOAT.  The parameter to control the number of principal 
+components to calculate from the input data. If components_param is INTEGER, 
+it is used for denoting the number of principal components (<em>k</em>) to 
+compute. If components_param is FLOAT, the algorithm would return enough 
+principal vectors so that the ratio of the sum of the eigenvalues collected 
+thus far to the sum of all eigenvalues is greater than this parameter.</DD>
 
 <DT>grouping_cols (optional)</DT>
 <DD>TEXT, default: NULL.  Currently <em>grouping_cols</em> is present as a placeholder for forward
@@ -178,13 +190,14 @@ contain values between 1 and <em>M</em>.</DD>
    An independent PCA model will be computed for each combination of the grouping columns.</DD>
 
 <DT>lanczos_iter (optional)</DT>
-<DD>INTEGER, default: minimum of {k+40, smallest matrix dimension}.  The number of Lanczos iterations for the SVD calculation.
+<DD>INTEGER, default: minimum of {k+40, smallest matrix dimension}.  
+The number of Lanczos iterations for the SVD calculation.
 The Lanczos iteration number roughly corresponds to the accuracy of the SVD
 calculation, and a higher iteration number corresponds to greater accuracy
-but longer computation time.  The number of iterations must be at least as
-large as the value of <em>k</em>,  but no larger than the smallest dimension
- of the matrix.  If the iteration number is given as zero, then the default
-  number of iterations is used.</DD>
+but longer computation time. The number of iterations must be at least as
+large as the value of <em>k</em>, but no larger than the smallest dimension 
+of the matrix.  If the iteration number is given as zero, then the default 
+number of iterations is used.</DD>
 
 <DT>use_correlation (optional)</DT>
 <DD>BOOLEAN, default FALSE.  Whether to use the correlation matrix for calculating the principal components instead of the covariance matrix. Currently
@@ -240,16 +253,17 @@ CREATE TABLE mat (
     row_id integer,
     row_vec double precision[]
 );
-COPY mat (row_id, row_vec) FROM stdin;
-1	{1,2,3}
-2	{2,1,2}
-3	{3,2,1}
+COPY mat (row_id, row_vec) FROM stdin DELIMITER '|';
+1|{1,2,3}
+2|{2,1,2}
+3|{3,2,1}
 \\.
 </pre>
 
--# Run the PCA function:
+-# Run the PCA function for a fixed number of components:
 <pre class="example">
-DROP TABLE result_table;
+DROP TABLE IF EXISTS result_table;
+DROP TABLE IF EXISTS result_table_mean;
 SELECT pca_train( 'mat',
                   'result_table',
                   'row_id',
@@ -263,11 +277,34 @@ SELECT * FROM result_table;
 </pre>
 Result
 <pre class="result">
- row_id |                     principal_components                     |     eigen_values
---------+--------------------------------------------------------------+----------------------
-      1 | {-0.707106781186548,-1.2490009027033e-16,0.707106781186548}  |      1.4142135623731
-      2 | {5.55111512312578e-17,1,0}                                   |    0.577350269189626
-      3 | {-0.707106781186547,1.11022302462516e-16,-0.707106781186548} | 1.07795017977832e-16
+ row_id |                     principal_components                     |       std_dev        |      proportion      
+--------+--------------------------------------------------------------+----------------------+----------------------
+      1 | {-0.707106781186547,-1.6306400674182e-16,0.707106781186547}  |     1.41421356237309 |    0.857142857142245
+      2 | {-1.66533453693773e-16,1,5.55111512312578e-17}               |    0.577350269189626 |    0.142857142857041
+      3 | {-0.707106781186548,1.11022302462516e-16,-0.707106781186547} | 1.59506745224211e-16 | 1.09038864737157e-32
+</pre>
+
+-# Run the PCA function for a proportion of variance:
+<pre class="example">
+DROP TABLE IF EXISTS result_table;
+DROP TABLE IF EXISTS result_table_mean;
+SELECT pca_train( 'mat',
+                  'result_table',
+                  'row_id',
+                  0.9
+                );
+</pre>
+
+-# View the PCA results:
+<pre class="example">
+SELECT * FROM result_table;
+</pre>
+Result
+<pre class="result">
+ row_id |                     principal_components                     |      std_dev      |    proportion     
+--------+--------------------------------------------------------------+-------------------+-------------------
+      1 | {-0.707106781186548,-3.46944695195361e-17,0.707106781186548} |   1.4142135623731 | 0.857142857142245
+      2 | {2.22044604925031e-16,-1,1.11022302462516e-16}               | 0.577350269189626 | 0.142857142857041
 </pre>
 
 @anchor notes
@@ -276,7 +313,8 @@ Result
 - Table names can be optionally schema qualified (current_schemas() would be
 searched if a schema name is not provided) and all table and column names
 should follow case-sensitivity and quoting rules per the database.
-(For instance, 'mytable' and 'MyTable' both resolve to the same entity, i.e. 'mytable'.
+(For instance, 'mytable' and 'MyTable' both resolve to the same entity, i.e. 
+'mytable'.
 If mixed-case or multi-byte characters are desired for entity names then the
 string should be double-quoted; in this case the input would be '"MyTable"').
 
@@ -286,6 +324,11 @@ become dense during the training process. Thus, this implementation
 automatically densifies sparse matrix input, and there should be no expected
  performance improvement in using sparse matrix input over dense matrix input.
 
+- If both <em>lanczos_iter</em> and proportion of variance (via the 
+<em>grouping_cols</em>) is defined, <em>lanczos_iter</em> will 
+take precedence in determining the number of principal components (i.e. the 
+number of principal components will not be greater than <em>lanczos_iter</em> 
+even if the target proportion is not reached).
 
 @anchor background_pca
 @par Technical Background
@@ -305,8 +348,8 @@ PCA then computes the SVD matrix factorization
 \hat{\boldsymbol X} =  {\boldsymbol U}{\boldsymbol \Sigma}{\boldsymbol V}^T
 \f]
 where \f$ {\boldsymbol \Sigma} \f$ is a diagonal matrix.  The eigenvalues are
-recovered as the entries of \f$ {\boldsymbol \Sigma}/(\sqrt{N-1}) \f$, and the principal
-components are the rows of  \f$ {\boldsymbol V} \f$.
+recovered as the entries of \f$ {\boldsymbol \Sigma}/(\sqrt{(N-1)} \f$, and the principal
+components are the rows of  \f$ {\boldsymbol V} \f$. The reasoning behind using N − 1 instead of N to calculate the covariance is <a href="https://en.wikipedia.org/wiki/Bessel%27s_correction">Bessel's correction</a>.
 
 
 It is important to note that the PCA implementation assumes that the user will
@@ -354,7 +397,8 @@ MADLIB_SCHEMA.pca_train(
     grouping_cols         TEXT,    -- Comma-separated list of grouping columns (Default: NULL)
     lanczos_iter          INTEGER, -- The number of Lanczos iterations for the SVD calculation (Default: min(k+40, smallest Matrix dimension))
     use_correlation       BOOLEAN, -- If True correlation matrix is used for principal components (Default: False)
-    result_summary_table  TEXT     -- Table name to store summary of results (Default: NULL)
+    result_summary_table  TEXT,    -- Table name to store summary of results (Default: NULL)
+    variance              DOUBLE PRECISION   -- The proportion of variance (Default: NULL)
 )
 RETURNS VOID AS $$
 PythonFunction(pca, pca, pca)
@@ -365,6 +409,21 @@ m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 -- Overloaded functions for optional parameters
 -- -----------------------------------------------------------------------
 
+CREATE OR REPLACE FUNCTION
+MADLIB_SCHEMA.pca_train(
+    source_table    TEXT,   -- Source table name (dense matrix)
+    pc_table        TEXT,   -- Output table name for the principal components
+    row_id          TEXT,   -- Column name for the ID for each row
+    k               INTEGER,-- Number of principal components to compute
+    grouping_cols   TEXT,   -- Comma-separated list of grouping columns
+    lanczos_iter    INTEGER,-- The number of Lanczos iterations for the SVD calculation
+    use_correlation BOOLEAN, -- If True correlation matrix is used for principal components
+    result_summary_table  TEXT    -- Table name to store summary of results (Default: NULL)
+)
+RETURNS VOID AS $$
+    SELECT MADLIB_SCHEMA.pca_train($1, $2, $3, $4, $5, $6, $7, $8, NULL)
+$$ LANGUAGE SQL
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 
 CREATE OR REPLACE FUNCTION
 MADLIB_SCHEMA.pca_train(
@@ -377,7 +436,7 @@ MADLIB_SCHEMA.pca_train(
     use_correlation BOOLEAN -- If True correlation matrix is used for principal components
 )
 RETURNS VOID AS $$
-    SELECT MADLIB_SCHEMA.pca_train($1, $2, $3, $4, $5, $6, $7, NULL)
+    SELECT MADLIB_SCHEMA.pca_train($1, $2, $3, $4, $5, $6, $7, NULL, NULL)
 $$ LANGUAGE SQL
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 
@@ -392,7 +451,7 @@ MADLIB_SCHEMA.pca_train(
     lanczos_iter   INTEGER -- The number of Lanczos iterations for the SVD calculation
 )
 RETURNS VOID AS $$
-    SELECT MADLIB_SCHEMA.pca_train($1, $2, $3, $4, $5, $6, False , NULL)
+    SELECT MADLIB_SCHEMA.pca_train($1, $2, $3, $4, $5, $6, False , NULL, NULL)
 $$ LANGUAGE SQL
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 
@@ -406,7 +465,7 @@ MADLIB_SCHEMA.pca_train(
     grouping_cols  TEXT    -- Comma-separated list of grouping columns
 )
 RETURNS VOID AS $$
-    SELECT MADLIB_SCHEMA.pca_train($1, $2, $3, $4, $5, 0, False , NULL)
+    SELECT MADLIB_SCHEMA.pca_train($1, $2, $3, $4, $5, 0, False , NULL, NULL)
 $$ LANGUAGE SQL
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 
@@ -419,11 +478,82 @@ MADLIB_SCHEMA.pca_train(
     k              INTEGER -- Number of principal components to compute
 )
 RETURNS VOID AS $$
-    SELECT MADLIB_SCHEMA.pca_train($1, $2, $3, $4, NULL, 0, False, NULL)
+    SELECT MADLIB_SCHEMA.pca_train($1, $2, $3, $4, NULL, 0, False, NULL, NULL)
+$$ LANGUAGE SQL
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
+
+CREATE OR REPLACE FUNCTION
+MADLIB_SCHEMA.pca_train(
+    source_table    TEXT,   -- Source table name (dense matrix)
+    pc_table        TEXT,   -- Output table name for the principal components
+    row_id          TEXT,   -- Column name for the ID for each row
+    variance        DOUBLE PRECISION, -- Proportion of variance
+    grouping_cols   TEXT,   -- Comma-separated list of grouping columns
+    lanczos_iter    INTEGER,-- The number of Lanczos iterations for the SVD calculation
+    use_correlation BOOLEAN, -- If True correlation matrix is used for principal components
+    result_summary_table  TEXT    -- Table name to store summary of results (Default: NULL)
+)
+RETURNS VOID AS $$
+    SELECT MADLIB_SCHEMA.pca_train($1, $2, $3, NULL, $5, $6, $7, $8, $4)
+$$ LANGUAGE SQL
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
+
+CREATE OR REPLACE FUNCTION
+MADLIB_SCHEMA.pca_train(
+    source_table    TEXT,   -- Source table name (dense matrix)
+    pc_table        TEXT,   -- Output table name for the principal components
+    row_id          TEXT,   -- Column name for the ID for each row
+    variance        DOUBLE PRECISION, -- Proportion of variance
+    grouping_cols   TEXT,   -- Comma-separated list of grouping columns
+    lanczos_iter    INTEGER,-- The number of Lanczos iterations for the SVD calculation
+    use_correlation BOOLEAN -- If True correlation matrix is used for principal components
+)
+RETURNS VOID AS $$
+    SELECT MADLIB_SCHEMA.pca_train($1, $2, $3, NULL, $5, $6, $7, NULL, $4)
 $$ LANGUAGE SQL
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 
 
+CREATE OR REPLACE FUNCTION
+MADLIB_SCHEMA.pca_train(
+    source_table   TEXT,   -- Source table name (dense matrix)
+    pc_table       TEXT,   -- Output table name for the principal components
+    row_id         TEXT,   -- Column name for the ID for each row
+    variance       DOUBLE PRECISION, -- Proportion of variance
+    grouping_cols  TEXT,   -- Comma-separated list of grouping columns
+    lanczos_iter   INTEGER -- The number of Lanczos iterations for the SVD calculation
+)
+RETURNS VOID AS $$
+    SELECT MADLIB_SCHEMA.pca_train($1, $2, $3, NULL, $5, $6, False , NULL, $4)
+$$ LANGUAGE SQL
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
+
+
+CREATE OR REPLACE FUNCTION
+MADLIB_SCHEMA.pca_train(
+    source_table   TEXT,   -- Source table name (dense matrix)
+    pc_table       TEXT,   -- Output table name for the principal components
+    row_id         TEXT,   -- Column name for the ID for each row
+    variance       DOUBLE PRECISION, -- Proportion of variance
+    grouping_cols  TEXT    -- Comma-separated list of grouping columns
+)
+RETURNS VOID AS $$
+    SELECT MADLIB_SCHEMA.pca_train($1, $2, $3, NULL, $5, 0, False , NULL, $4)
+$$ LANGUAGE SQL
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
+
+
+CREATE OR REPLACE FUNCTION
+MADLIB_SCHEMA.pca_train(
+    source_table   TEXT,   -- Source table name (dense matrix)
+    pc_table       TEXT,   -- Output table name for the principal components
+    row_id         TEXT,   -- Column name for the ID for each row
+    variance       DOUBLE PRECISION -- Proportion of variance
+)
+RETURNS VOID AS $$
+    SELECT MADLIB_SCHEMA.pca_train($1, $2, $3, NULL, NULL, 0, False, NULL, $4)
+$$ LANGUAGE SQL
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 
 -- Information Functions
 -- -----------------------------------------------------------------------
@@ -466,7 +596,8 @@ MADLIB_SCHEMA.pca_sparse_train(
     grouping_cols        TEXT,     -- Comma-separated list of grouping columns (Default: NULL)
     lanczos_iter         INTEGER,  -- The number of Lanczos iterations for the SVD calculation (Default: min(k+40, smallest Matrix dimension))
     use_correlation      BOOLEAN,  -- If True correlation matrix is used for principal components (Default: False)
-    result_summary_table TEXT      -- Table name to store summary of results (Default: NULL)
+    result_summary_table TEXT,      -- Table name to store summary of results (Default: NULL)
+    variance             DOUBLE PRECISION -- The proportion of variance (Default: NULL)
 )
 RETURNS VOID AS $$
 PythonFunction(pca, pca, pca_sparse)
@@ -476,6 +607,26 @@ m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 
 -- Overloaded functions for optional parameters
 -- -----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION
+MADLIB_SCHEMA.pca_sparse_train(
+    source_table         TEXT,     -- Source table name (dense matrix)
+    pc_table             TEXT,     -- Output table name for the principal components
+    row_id               TEXT,     -- Name of 'row_id' column in sparse matrix representation
+    col_id               TEXT,     -- Name of 'col_id' column in sparse matrix representation
+    val_id               TEXT,     -- Name of 'val_id' column in sparse matrix representation
+    row_dim              INTEGER,  -- Number of rows in the sparse matrix
+    col_dim              INTEGER,  -- Number of columns in the sparse matrix
+    k                    INTEGER,  -- Number of eigenvectors with dominant eigenvalues, sorted decreasingly
+    grouping_cols        TEXT,     -- Comma-separated list of grouping columns (Default: NULL)
+    lanczos_iter         INTEGER,  -- The number of Lanczos iterations for the SVD calculation (Default: min(k+40, smallest Matrix dimension))
+    use_correlation      BOOLEAN,  -- If True correlation matrix is used for principal components (Default: False)
+    result_summary_table TEXT      -- Table name to store summary of results (Default: NULL) 
+)
+RETURNS VOID AS $$
+    SELECT MADLIB_SCHEMA.pca_sparse_train($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, NULL)
+$$ LANGUAGE SQL
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
+
 CREATE OR REPLACE FUNCTION
 MADLIB_SCHEMA.pca_sparse_train(
     source_table    TEXT,     -- Source table name (dense matrix)
@@ -491,7 +642,7 @@ MADLIB_SCHEMA.pca_sparse_train(
     use_correlation BOOLEAN   -- If True correlation matrix is used for principal components
 )
 RETURNS VOID AS $$
-    SELECT MADLIB_SCHEMA.pca_sparse_train($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NULL)
+    SELECT MADLIB_SCHEMA.pca_sparse_train($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NULL, NULL)
 $$ LANGUAGE SQL
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 
@@ -510,7 +661,7 @@ MADLIB_SCHEMA.pca_sparse_train(
     lanczos_iter  INTEGER   -- The number of Lanczos iterations for the SVD calculation
 )
 RETURNS VOID AS $$
-    SELECT MADLIB_SCHEMA.pca_sparse_train($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, False , NULL)
+    SELECT MADLIB_SCHEMA.pca_sparse_train($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, False , NULL, NULL)
 $$ LANGUAGE SQL
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 
@@ -528,7 +679,7 @@ MADLIB_SCHEMA.pca_sparse_train(
     grouping_cols TEXT      -- Comma-separated list of grouping columns
 )
 RETURNS VOID AS $$
-    SELECT MADLIB_SCHEMA.pca_sparse_train($1, $2, $3, $4, $5, $6, $7, $8, $9, 0, False , NULL)
+    SELECT MADLIB_SCHEMA.pca_sparse_train($1, $2, $3, $4, $5, $6, $7, $8, $9, 0, False , NULL, NULL)
 $$ LANGUAGE SQL
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 
@@ -545,12 +696,101 @@ MADLIB_SCHEMA.pca_sparse_train(
     k             INTEGER   -- Number of principal components to compute
 )
 RETURNS VOID AS $$
-    SELECT MADLIB_SCHEMA.pca_sparse_train($1, $2, $3, $4, $5, $6, $7, $8, NULL, 0, False, NULL)
+    SELECT MADLIB_SCHEMA.pca_sparse_train($1, $2, $3, $4, $5, $6, $7, $8, NULL, 0, False, NULL, NULL)
+$$ LANGUAGE SQL
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
+
+CREATE OR REPLACE FUNCTION
+MADLIB_SCHEMA.pca_sparse_train(
+    source_table         TEXT,     -- Source table name (dense matrix)
+    pc_table             TEXT,     -- Output table name for the principal components
+    row_id               TEXT,     -- Name of 'row_id' column in sparse matrix representation
+    col_id               TEXT,     -- Name of 'col_id' column in sparse matrix representation
+    val_id               TEXT,     -- Name of 'val_id' column in sparse matrix representation
+    row_dim              INTEGER,  -- Number of rows in the sparse matrix
+    col_dim              INTEGER,  -- Number of columns in the sparse matrix
+    variance             DOUBLE PRECISION, -- proportion of variance
+    grouping_cols        TEXT,     -- Comma-separated list of grouping columns (Default: NULL)
+    lanczos_iter         INTEGER,  -- The number of Lanczos iterations for the SVD calculation (Default: min(k+40, smallest Matrix dimension))
+    use_correlation      BOOLEAN,  -- If True correlation matrix is used for principal components (Default: False)
+    result_summary_table TEXT      -- Table name to store summary of results (Default: NULL) 
+)
+RETURNS VOID AS $$
+    SELECT MADLIB_SCHEMA.pca_sparse_train($1, $2, $3, $4, $5, $6, $7, NULL, $9, $10, $11, $12, $8)
+$$ LANGUAGE SQL
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
+
+CREATE OR REPLACE FUNCTION
+MADLIB_SCHEMA.pca_sparse_train(
+    source_table    TEXT,     -- Source table name (dense matrix)
+    pc_table        TEXT,     -- Output table name for the principal components
+    row_id          TEXT,     -- Column name for the ID for each row
+    col_id          TEXT,     -- Name of 'col_id' column in sparse matrix representation
+    val_id          TEXT,     -- Name of 'val_id' column in sparse matrix representation
+    row_dim         INTEGER,  -- Number of rows in the sparse matrix
+    col_dim         INTEGER,  -- Number of columns in the sparse matrix
+    variance        DOUBLE PRECISION, -- proportion of variance
+    grouping_cols   TEXT,     -- Comma-separated list of grouping columns
+    lanczos_iter    INTEGER,  -- The number of Lanczos iterations for the SVD calculation
+    use_correlation BOOLEAN   -- If True correlation matrix is used for principal components
+)
+RETURNS VOID AS $$
+    SELECT MADLIB_SCHEMA.pca_sparse_train($1, $2, $3, $4, $5, $6, $7, NULL, $9, $10, $11, NULL, $8)
 $$ LANGUAGE SQL
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 
 
+CREATE OR REPLACE FUNCTION
+MADLIB_SCHEMA.pca_sparse_train(
+    source_table  TEXT,     -- Source table name (dense matrix)
+    pc_table      TEXT,     -- Output table name for the principal components
+    row_id        TEXT,     -- Column name for the ID for each row
+    col_id        TEXT,     -- Name of 'col_id' column in sparse matrix representation
+    val_id        TEXT,     -- Name of 'val_id' column in sparse matrix representation
+    row_dim       INTEGER,  -- Number of rows in the sparse matrix
+    col_dim       INTEGER,  -- Number of columns in the sparse matrix
+    variance      DOUBLE PRECISION, -- proportion of variance
+    grouping_cols TEXT,     -- Comma-separated list of grouping columns
+    lanczos_iter  INTEGER   -- The number of Lanczos iterations for the SVD calculation
+)
+RETURNS VOID AS $$
+    SELECT MADLIB_SCHEMA.pca_sparse_train($1, $2, $3, $4, $5, $6, $7, NULL, $9, $10, False , NULL, $8)
+$$ LANGUAGE SQL
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 
+
+CREATE OR REPLACE FUNCTION
+MADLIB_SCHEMA.pca_sparse_train(
+    source_table  TEXT,     -- Source table name (dense matrix)
+    pc_table      TEXT,     -- Output table name for the principal components
+    row_id        TEXT,     -- Column name for the ID for each row
+    col_id        TEXT,     -- Name of 'col_id' column in sparse matrix representation
+    val_id        TEXT,     -- Name of 'val_id' column in sparse matrix representation
+    row_dim       INTEGER,  -- Number of rows in the sparse matrix
+    col_dim       INTEGER,  -- Number of columns in the sparse matrix
+    variance      DOUBLE PRECISION, -- proportion of variance
+    grouping_cols TEXT      -- Comma-separated list of grouping columns
+)
+RETURNS VOID AS $$
+    SELECT MADLIB_SCHEMA.pca_sparse_train($1, $2, $3, $4, $5, $6, $7, NULL, $9, 0, False , NULL, $8)
+$$ LANGUAGE SQL
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
+
+CREATE OR REPLACE FUNCTION
+MADLIB_SCHEMA.pca_sparse_train(
+    source_table  TEXT,     -- Source table name (dense matrix)
+    pc_table      TEXT,     -- Output table name for the principal components
+    row_id        TEXT,     -- Column name for the ID for each row
+    col_id        TEXT,     -- Name of 'col_id' column in sparse matrix representation
+    val_id        TEXT,     -- Name of 'val_id' column in sparse matrix representation
+    row_dim       INTEGER,  -- Number of rows in the sparse matrix
+    col_dim       INTEGER,  -- Number of columns in the sparse matrix
+    variance      DOUBLE PRECISION -- proportion of variance
+)
+RETURNS VOID AS $$
+    SELECT MADLIB_SCHEMA.pca_sparse_train($1, $2, $3, $4, $5, $6, $7, NULL, NULL, 0, False, NULL, $8)
+$$ LANGUAGE SQL
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 -- -----------------------------------------------------------------------
 -- Information Functions
 -- -----------------------------------------------------------------------

--- a/src/ports/postgres/modules/pca/test/pca.sql_in
+++ b/src/ports/postgres/modules/pca/test/pca.sql_in
@@ -67,6 +67,57 @@ NULL, 0, FALSE, 'result_table_214712398172490838');
 select * from result_table_214712398172490837;
 select * from result_table_214712398172490838;
 
+drop table if exists result_table_214712398172490837;
+drop table if exists result_table_214712398172490837_mean;
+drop table if exists result_table_214712398172490838;
+select pca_train('mat', 'result_table_214712398172490837', 'row_id', 5,
+NULL, 5, FALSE, 'result_table_214712398172490838');
+select * from result_table_214712398172490837;
+select * from result_table_214712398172490838;
+
+drop table if exists result_table_214712398172490837;
+drop table if exists result_table_214712398172490837_mean;
+select pca_train('mat', 'result_table_214712398172490837', 'row_id', 0.8);
+select * from result_table_214712398172490837;
+
+drop table if exists result_table_214712398172490837;
+drop table if exists result_table_214712398172490837_mean;
+select pca_train('mat', 'result_table_214712398172490837', 'row_id', 0.8, NULL);
+select * from result_table_214712398172490837;
+
+drop table if exists result_table_214712398172490837;
+drop table if exists result_table_214712398172490837_mean;
+select pca_train('mat', 'result_table_214712398172490837', 'row_id', 0.8, NULL, 0);
+select * from result_table_214712398172490837;
+
+drop table if exists result_table_214712398172490837;
+drop table if exists result_table_214712398172490837_mean;
+select pca_train('mat', 'result_table_214712398172490837', 'row_id', 0.8,
+NULL, 0, FALSE);
+select * from result_table_214712398172490837;
+
+drop table if exists result_table_214712398172490837;
+drop table if exists result_table_214712398172490837_mean;
+select pca_train('mat', 'result_table_214712398172490837', 'row_id', 0.8,
+NULL, 0, FALSE, NULL);
+select * from result_table_214712398172490837;
+
+drop table if exists result_table_214712398172490837;
+drop table if exists result_table_214712398172490837_mean;
+drop table if exists result_table_214712398172490838;
+select pca_train('mat', 'result_table_214712398172490837', 'row_id', 0.8,
+NULL, 0, FALSE, 'result_table_214712398172490838');
+select * from result_table_214712398172490837;
+select * from result_table_214712398172490838;
+
+drop table if exists result_table_214712398172490837;
+drop table if exists result_table_214712398172490837_mean;
+drop table if exists result_table_214712398172490838;
+select pca_train('mat', 'result_table_214712398172490837', 'row_id', 0.8,
+NULL, 5, FALSE, 'result_table_214712398172490838');
+select * from result_table_214712398172490837;
+select * from result_table_214712398172490838;
+
 -- SPARSE PCA: Make sure all possible default calls for sparse PCA work
 -----------------------------------------------------------------------------
 
@@ -134,6 +185,49 @@ select pca_sparse_train('sparse_mat', 'result_table_214712398172490837',
 select * from result_table_214712398172490837;
 select * from result_table_214712398172490838;
 
+
+drop table if exists result_table_214712398172490837;
+drop table if exists result_table_214712398172490837_mean;
+select pca_sparse_train('sparse_mat', 'result_table_214712398172490837',
+'row_id', 'col_id', 'val_id', 10, 10, 0.8);
+select * from result_table_214712398172490837;
+
+drop table if exists result_table_214712398172490837;
+drop table if exists result_table_214712398172490837_mean;
+select pca_sparse_train('sparse_mat', 'result_table_214712398172490837',
+'row_id', 'col_id', 'val_id', 10, 10, 0.8, NULL);
+select * from result_table_214712398172490837;
+
+
+drop table if exists result_table_214712398172490837;
+drop table if exists result_table_214712398172490837_mean;
+select pca_sparse_train('sparse_mat', 'result_table_214712398172490837',
+'row_id', 'col_id', 'val_id', 10, 10, 0.8, NULL, 0);
+select * from result_table_214712398172490837;
+
+
+drop table if exists result_table_214712398172490837;
+drop table if exists result_table_214712398172490837_mean;
+select pca_sparse_train('sparse_mat', 'result_table_214712398172490837',
+'row_id', 'col_id', 'val_id', 10, 10, 0.8, NULL, 0, FALSE);
+select * from result_table_214712398172490837;
+
+
+drop table if exists result_table_214712398172490837;
+drop table if exists result_table_214712398172490837_mean;
+select pca_sparse_train('sparse_mat', 'result_table_214712398172490837',
+'row_id', 'col_id', 'val_id', 10, 10, 0.8, NULL, 0, FALSE, NULL);
+select * from result_table_214712398172490837;
+
+
+drop table if exists result_table_214712398172490837;
+drop table if exists result_table_214712398172490837_mean;
+drop table if exists result_table_214712398172490838;
+select pca_sparse_train('sparse_mat', 'result_table_214712398172490837',
+'row_id', 'col_id', 'val_id', 10, 10, 0.8, NULL, 0, FALSE, 'result_table_214712398172490838');
+select * from result_table_214712398172490837;
+select * from result_table_214712398172490838;
+
 -------------------------------------------------------------------------
 -- test a different column name
 alter table sparse_mat rename column row_id to rownr;
@@ -194,7 +288,7 @@ select * from table_b;
 --Check that the two formats generate the same result
 --We take the square of each element to get around sign differences
 SELECT assert(
-    relative_error(table_a.eigen_values, table_b.eigen_values) < 1e-2
+    relative_error(table_a.std_dev, table_b.std_dev) < 1e-2
     AND
     relative_error(
         array_mult(table_a.principal_components, table_a.principal_components),


### PR DESCRIPTION
JIRA: MADLIB-948
- Added a new functionality where the user can specify the proportion of variance to be covered by the principal components. This function does not take an integer k value, instead a float value (between 0 and 1) is accepted.
- The interface has been updated with new parameter names to reflect the change.
- The sparse and block variants of PCA are updated to employ this functionality.
- The proportion of variance covered by each principal component is added to the output for the new function as well as the old one.
- The implementation required splitting the SVD function into two parts and applying various levels of wrappers so that the general SVD interface does not change while giving PCA enough access to manipulate the intermediate tables.