### PR TITLE
Decision Tree: Fix format specifier in online help

### DIFF
--- a/src/ports/postgres/modules/recursive_partitioning/decision_tree.py_in
+++ b/src/ports/postgres/modules/recursive_partitioning/decision_tree.py_in
@@ -295,17 +295,17 @@ CREATE TABLE dummy_dt_con_src (
 );
 
 INSERT INTO dummy_dt_src VALUES
-(1, '{0}'::INTEGER[], ARRAY[0], 0.5),
-(2, '{0}'::INTEGER[], ARRAY[1], 0.5),
-(3, '{0}'::INTEGER[], ARRAY[4], 0.5),
-(4, '{0}'::INTEGER[], ARRAY[4], 0.5),
-(5, '{0}'::INTEGER[], ARRAY[4], 0.5),
-(6, '{0}'::INTEGER[], ARRAY[5], 0.1),
-(7, '{0}'::INTEGER[], ARRAY[6], 0.1),
-(8, '{1}'::INTEGER[], ARRAY[9], 0.1);
-(9, '{1}'::INTEGER[], ARRAY[9], 0.1);
-(10, '{1}'::INTEGER[], ARRAY[9], 0.1);
-(11, '{1}'::INTEGER[], ARRAY[9], 0.1);
+(1, '{{0}}'::INTEGER[], ARRAY[0], 0.5),
+(2, '{{0}}'::INTEGER[], ARRAY[1], 0.5),
+(3, '{{0}}'::INTEGER[], ARRAY[4], 0.5),
+(4, '{{0}}'::INTEGER[], ARRAY[4], 0.5),
+(5, '{{0}}'::INTEGER[], ARRAY[4], 0.5),
+(6, '{{0}}'::INTEGER[], ARRAY[5], 0.1),
+(7, '{{0}}'::INTEGER[], ARRAY[6], 0.1),
+(8, '{{1}}'::INTEGER[], ARRAY[9], 0.1);
+(9, '{{1}}'::INTEGER[], ARRAY[9], 0.1);
+(10, '{{1}}'::INTEGER[], ARRAY[9], 0.1);
+(11, '{{1}}'::INTEGER[], ARRAY[9], 0.1);
 
 DROP TABLE IF EXISTS tree_out, tree_out_summary;
 SELECT madlib.tree_train(


### PR DESCRIPTION
Jira: MADLIB-968

Using tree_train('example') returned a tuple index error, due to invalid format specifier.
This fix add extra {} to escape existing {} in the python string.

@iyerr3 