### PR TITLE
Release1.9alpha: Minor fixes for RC2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -245,6 +245,32 @@ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
 ***********************************************************************
+
+Source code under src/madpack/yaml is taken from PyYAML project and is 
+available under the MIT license:
+
+Copyright (c) 2006 Kirill Simonov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+***********************************************************************
+
 The rest of the source code, unless explicitly marked with an Apache License
 header, should be assumed to be coming from previous life of MADlib as a 
 BSD licensed project and is available under the following license:

--- a/pom.xml
+++ b/pom.xml
@@ -658,7 +658,7 @@
               <exclude>src/ports/postgres/modules/svm/__init__.py_in</exclude>
               <exclude>src/ports/postgres/modules/svm/svm.py_in</exclude>
               <exclude>src/ports/postgres/modules/svm/svm.sql_in</exclude>
-              <exclude>src/ports/postgres/modules/svm/test/linear_svm.sql_in</exclude>
+              <exclude>src/ports/postgres/modules/svm/test/svm.sql_in</exclude>
               <exclude>src/ports/postgres/modules/tsa/__init__.py_in</exclude>
               <exclude>src/ports/postgres/modules/tsa/arima.py_in</exclude>
               <exclude>src/ports/postgres/modules/tsa/arima.sql_in</exclude>

--- a/src/ports/postgres/modules/svm/kernel_approximation.py_in
+++ b/src/ports/postgres/modules/svm/kernel_approximation.py_in
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 from __future__ import division
 
 import plpy


### PR DESCRIPTION
JIRA: MADLIB-972

-Modified LICENSE file for PyYAML license (MIT)
-Modified pom.xml to reflect the name change on linear_svm.sql_in -> svm.sql_in
-Added Apache header for kernel_approximation.py_in