### PR TITLE
Recursive_partitioning: Fix random forrest error message

### DIFF
--- a/src/ports/postgres/modules/recursive_partitioning/decision_tree.py_in
+++ b/src/ports/postgres/modules/recursive_partitioning/decision_tree.py_in
@@ -669,6 +669,8 @@ def _get_n_and_deplist(training_table_name, dependent_variable, filter_null):
                    source=training_table_name,
                    filter_null=filter_null)
     r = plpy.execute(sql)[0]
+    if r['n_rows'] is None:
+        return None, None
     return long(r['n_rows']), r['dep']
 # ------------------------------------------------------------
 

--- a/src/ports/postgres/modules/recursive_partitioning/random_forest.py_in
+++ b/src/ports/postgres/modules/recursive_partitioning/random_forest.py_in
@@ -335,6 +335,9 @@ def forest_train(
                     n_rows, dep_list = _get_n_and_deplist(training_table_name,
                                                           dependent_variable,
                                                           filter_null)
+                    _assert(n_rows, "Random forest error: There should be at " +
+                        "least one data point where all features are non NULL" +
+                        " for each class.")
                     dep_list.sort()
                     dep_col_str = ("case when " + dependent_variable +
                                    " then 'True' else 'False' end") if is_bool else dependent_variable


### PR DESCRIPTION
JIRA: MADLIB-975
Random forest train gave a non-descript error if every data point had a NULL feature. Added an if check and and assert to give a proper description of the situation.