### PR TITLE
        Elastic Net: Skip arrays with NULL values in train

### DIFF
--- a/src/modules/convex/utils_regularization.cpp
+++ b/src/modules/convex/utils_regularization.cpp
@@ -79,13 +79,13 @@ class ScalesState
 AnyType utils_var_scales_transition::run (AnyType& args)
 {
     ScalesState<MutableArrayHandle<double> > state = args[0];
+    MappedColumnVector x(NULL);
     try {
-        args[1].getAs<MappedColumnVector>();
+        new (&x) MappedColumnVector(args[1].getAs<MappedColumnVector>());
     } catch(const ArrayWithNullException &e) {
       //  warning("Input array contains NULL values, skipping it for mean and std computations");
         return state;
     }
-    MappedColumnVector x = args[1].getAs<MappedColumnVector>();
     if (state.numRows == 0)
     {
         int dimension = args[2].getAs<int>();
@@ -157,13 +157,13 @@ AnyType __utils_var_scales_result::run (AnyType& args)
 
 AnyType utils_normalize_data::run (AnyType& args)
 {
+    MutableMappedColumnVector x(NULL);
     try {
-        args[0].getAs<MutableMappedColumnVector>();
+        new (&x) MutableMappedColumnVector(args[0].getAs<MutableMappedColumnVector>());
     } catch(const ArrayWithNullException &e) {
        // warning("Input array contains NULL values, skipping this array normalization");
         return Null();
     }
-    MutableMappedColumnVector x = args[0].getAs<MutableMappedColumnVector>();
     MappedColumnVector mean = args[1].getAs<MappedColumnVector>();
     MappedColumnVector std = args[2].getAs<MappedColumnVector>();
 

--- a/src/modules/convex/utils_regularization.cpp
+++ b/src/modules/convex/utils_regularization.cpp
@@ -79,8 +79,13 @@ class ScalesState
 AnyType utils_var_scales_transition::run (AnyType& args)
 {
     ScalesState<MutableArrayHandle<double> > state = args[0];
+    try {
+        args[1].getAs<MappedColumnVector>();
+    } catch(const ArrayWithNullException &e) {
+      //  warning("Input array contains NULL values, skipping it for mean and std computations");
+        return state;
+    }
     MappedColumnVector x = args[1].getAs<MappedColumnVector>();
-
     if (state.numRows == 0)
     {
         int dimension = args[2].getAs<int>();
@@ -99,7 +104,6 @@ AnyType utils_var_scales_transition::run (AnyType& args)
     }
 
     state.numRows++;
-
     return state;
 }
 
@@ -153,6 +157,12 @@ AnyType __utils_var_scales_result::run (AnyType& args)
 
 AnyType utils_normalize_data::run (AnyType& args)
 {
+    try {
+        args[0].getAs<MutableMappedColumnVector>();
+    } catch(const ArrayWithNullException &e) {
+       // warning("Input array contains NULL values, skipping this array normalization");
+        return Null();
+    }
     MutableMappedColumnVector x = args[0].getAs<MutableMappedColumnVector>();
     MappedColumnVector mean = args[1].getAs<MappedColumnVector>();
     MappedColumnVector std = args[2].getAs<MappedColumnVector>();

--- a/src/modules/elastic_net/elastic_net_utils.cpp
+++ b/src/modules/elastic_net/elastic_net_utils.cpp
@@ -30,12 +30,14 @@ AnyType __elastic_net_gaussian_predict::run (AnyType& args)
     }
 
     MappedColumnVector coef = args[0].getAs<MappedColumnVector>();
-    double intercept = args[1].getAs<double>();
     MappedColumnVector x = args[2].getAs<MappedColumnVector>();
+    double intercept = args[1].getAs<double>();
 
     double predict = intercept + sparse_dot(coef, x);
     return predict;
 }
+
+
 
 // ------------------------------------------------------------------------
 

--- a/src/ports/postgres/modules/convex/utils_regularization.py_in
+++ b/src/ports/postgres/modules/convex/utils_regularization.py_in
@@ -38,7 +38,6 @@ def __utils_ind_var_scales(**kwargs):
     return x_scales
 # ========================================================================
 
-
 def __utils_dep_var_scale(**kwargs):
     """
     The mean and standard deviation for each element of the dependent variable,
@@ -47,14 +46,22 @@ def __utils_dep_var_scale(**kwargs):
     The output will be stored in a temp table: a mean array and a std array
 
     This function is also used in lasso.
+
+    Parameters:
+    schema_madlib -- madlib schema
+    tbl_data -- original data
+    col_ind_var -- independent variables column
+    col_dep_var -- dependent variable column
     """
+
     y_scale = plpy.execute(
         """
         select
-            avg({col_dep_var}) as mean,
+            avg(case when not {schema_madlib}.array_contains_null({col_ind_var}) then {col_dep_var} end) as mean,
             1 as std
         from {tbl_data}
         """.format(**kwargs))[0]
+
     return y_scale
 # ========================================================================
 

--- a/src/ports/postgres/modules/elastic_net/elastic_net_gaussian_fista.py_in
+++ b/src/ports/postgres/modules/elastic_net/elastic_net_gaussian_fista.py_in
@@ -282,7 +282,7 @@ def __elastic_net_gaussian_fista_train_compute(
                                  """)[0]['setting']
     plpy.execute("set client_min_messages to error")
 
-    (dimension, row_num) = __tbl_dimension_rownum(tbl_source, col_ind_var)
+    (dimension, row_num) = __tbl_dimension_rownum(schema_madlib, tbl_source, col_ind_var)
 
     # generate a full dict to ease the following string format
     # including several temporary table names

--- a/src/ports/postgres/modules/elastic_net/elastic_net_gaussian_igd.py_in
+++ b/src/ports/postgres/modules/elastic_net/elastic_net_gaussian_igd.py_in
@@ -268,7 +268,7 @@ def __elastic_net_gaussian_igd_train_compute(schema_madlib, tbl_source, col_ind_
                                  """)[0]['setting']
     plpy.execute("set client_min_messages to error")
 
-    (dimension, row_num) = __tbl_dimension_rownum(tbl_source, col_ind_var)
+    (dimension, row_num) = __tbl_dimension_rownum(schema_madlib, tbl_source, col_ind_var)
 
     # generate a full dict to ease the following string format
     # including several temporary table names

--- a/src/ports/postgres/modules/elastic_net/elastic_net_optimizer_fista.py_in
+++ b/src/ports/postgres/modules/elastic_net/elastic_net_optimizer_fista.py_in
@@ -326,7 +326,7 @@ def __elastic_net_fista_train_compute(schema_madlib, func_step_aggregate,
                                  """)[0]['setting']
     plpy.execute("set client_min_messages to error")
 
-    (dimension, row_num) = __tbl_dimension_rownum(tbl_source, col_ind_var)
+    (dimension, row_num) = __tbl_dimension_rownum(schema_madlib, tbl_source, col_ind_var)
 
     # generate a full dict to ease the following string format
     # including several temporary table names

--- a/src/ports/postgres/modules/elastic_net/elastic_net_optimizer_igd.py_in
+++ b/src/ports/postgres/modules/elastic_net/elastic_net_optimizer_igd.py_in
@@ -298,7 +298,7 @@ def __elastic_net_igd_train_compute(schema_madlib, func_step_aggregate,
                                  """)[0]['setting']
     plpy.execute("set client_min_messages to error")
 
-    (dimension, row_num) = __tbl_dimension_rownum(tbl_source, col_ind_var)
+    (dimension, row_num) = __tbl_dimension_rownum(schema_madlib, tbl_source, col_ind_var)
 
     # generate a full dict to ease the following string format
     # including several temporary table names

--- a/src/ports/postgres/modules/elastic_net/elastic_net_utils.py_in
+++ b/src/ports/postgres/modules/elastic_net/elastic_net_utils.py_in
@@ -258,6 +258,10 @@ def __tbl_dimension_rownum(schema_madlib, tbl_source, col_ind_var):
                              """.format(tbl_source=tbl_source,
                                         col_ind_var=col_ind_var))[0]["dimension"]
     # total row number of data source table
+    # The WHERE clause here ignores rows in the table that contain one or more NULLs in the
+    # independent variable (x). There is no NULL check made for the dependent variable (y),
+    # since one of the hard requirements/assumptions of the input data to elastic_net is that the
+    # dependent variable cannot be NULL.
     row_num = plpy.execute("""
                            select count(*) from {tbl_source}
                            WHERE not {schema_madlib}.array_contains_null({col_ind_var})

--- a/src/ports/postgres/modules/elastic_net/elastic_net_utils.py_in
+++ b/src/ports/postgres/modules/elastic_net/elastic_net_utils.py_in
@@ -212,7 +212,8 @@ def __compute_data_scales(args):
     if args["family"] == "binomial":
         args["y_scale"] = dict(mean=0, std=1)
     else:
-        args["y_scale"] = __utils_dep_var_scale(tbl_data=args["tbl_source"], col_dep_var=args["col_dep_var"])
+        args["y_scale"] = __utils_dep_var_scale(schema_madlib=args["schema_madlib"], tbl_data=args["tbl_source"], 
+            col_ind_var=args["col_ind_var"], col_dep_var=args["col_dep_var"])
 
     args["xmean_str"] = _array_to_string(args["x_scales"]["mean"])
 # ========================================================================
@@ -246,7 +247,7 @@ def __normalize_data(args):
 # ========================================================================
 
 
-def __tbl_dimension_rownum(tbl_source, col_ind_var):
+def __tbl_dimension_rownum(schema_madlib, tbl_source, col_ind_var):
     """
     Measure the dimension and row number of source data table
     """
@@ -259,7 +260,10 @@ def __tbl_dimension_rownum(tbl_source, col_ind_var):
     # total row number of data source table
     row_num = plpy.execute("""
                            select count(*) from {tbl_source}
-                           """.format(tbl_source=tbl_source))[0]["count"]
+                           WHERE not {schema_madlib}.array_contains_null({col_ind_var})
+                           """.format(tbl_source=tbl_source,
+                           schema_madlib=schema_madlib,
+                           col_ind_var=col_ind_var))[0]["count"]
 
     return (dimension, row_num)
 # ========================================================================

--- a/src/ports/postgres/modules/elastic_net/test/elastic_net_install_check.sql_in
+++ b/src/ports/postgres/modules/elastic_net/test/elastic_net_install_check.sql_in
@@ -6,6 +6,7 @@
 DROP TABLE IF EXISTS lin_housing_wi;
 CREATE TABLE lin_housing_wi (id serial, x float8[],y float8);
 COPY lin_housing_wi (x, y) FROM STDIN NULL '?';
+{1,0.00632,18.00,2.310,NULL,0.5380,6.5750,NULL,4.0900,1,296.0,15.30,396.90,4.98}	24.00
 {1,0.00632,18.00,2.310,0,0.5380,6.5750,65.20,4.0900,1,296.0,15.30,396.90,4.98}	24.00
 {1,0.02731,0.00,7.070,0,0.4690,6.4210,78.90,4.9671,2,242.0,17.80,396.90,9.14}	21.60
 {1,0.02729,0.00,7.070,0,0.4690,7.1850,61.10,4.9671,2,242.0,17.80,392.83,4.03}	34.70
@@ -512,6 +513,9 @@ COPY lin_housing_wi (x, y) FROM STDIN NULL '?';
 {1,0.06076,0.00,11.930,0,0.5730,6.9760,91.00,2.1675,1,273.0,21.00,396.90,5.64}	23.90
 {1,0.10959,0.00,11.930,0,0.5730,6.7940,89.30,2.3889,1,273.0,21.00,393.45,6.48}	22.00
 {1,0.04741,0.00,11.930,0,0.5730,6.0300,80.80,2.5050,1,273.0,21.00,396.90,7.88}	11.90
+{1,0.06076,0.00,11.930,0,0.5730,6.9760,91.00,2.1675,1,273.0,21.00,396.90,NULL}	23.90
+{1,0.10959,0.00,11.930,NULL,0.5730,6.7940,89.30,2.3889,1,273.0,21.00,NULL,6.48}	22.00
+{NULL,0.04741,0.00,11.930,0,0.5730,6.0300,80.80,2.5050,1,273.0,21.00,396.90,7.88}	11.90
 \.
 
 DROP TABLE IF EXISTS elastic_type_src;
@@ -632,6 +636,7 @@ begin
                                 'id',
                                 'house_test_null_gaussian');
 
+
     EXECUTE 'drop table if exists house_en';
     PERFORM elastic_net_train(
         'lin_housing_wi',
@@ -666,6 +671,7 @@ begin
                                 'id',
                                 'house_test_null_binomial');
 
+
     EXECUTE 'drop table if exists house_en';
     PERFORM elastic_net_train(
         'lin_housing_wi',
@@ -699,6 +705,7 @@ begin
                                 'housing_test_null',
                                 'id',
                                 'house_test_null_binomial');
+
 
     EXECUTE 'DROP TABLE IF EXISTS elastic_type_res';
     PERFORM elastic_net_train('elastic_type_src',


### PR DESCRIPTION
        Jira: MADLIB-978

        Having NULL values in the input array of the training
        data was leading to an unhandled exception. This fix
        now catches the exception and skips such input arrays.
        The fix also modifies the code which was used to normalize
        the input data (independent variable), which now ignores
        such arrays with NULLs while normalizing.
        The number of rows in the input table was used while
        normalizing the data. The query used to get the number
        of rows is now changed to count only those rows that have
        no NULL values in the array.
        The mean of the dependent variable was still computed using
        an SQL command which was not ignoring the independent variables
        (arrays) with NULLs. They are ignored which computing the mean now.

@mktal 