### PR TITLE
Random Forest: Fix filtered feature related bug

### DIFF
--- a/methods/array_ops/src/pg_gp/array_ops.c
+++ b/methods/array_ops/src/pg_gp/array_ops.c
@@ -375,7 +375,7 @@ array_of_float(PG_FUNCTION_ARGS){
         ereport(ERROR,
                 (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
                  errmsg("invalid array length"),
-                 errdetail("array_of_bigint: Size should be in [1, 1e7], %d given", size)));
+                 errdetail("array_of_float: Size should be in [1, 1e7], %d given", size)));
     }
     Datum* array = palloc (sizeof(Datum)*size);
     for(int i = 0; i < size; ++i) {

--- a/src/ports/postgres/modules/recursive_partitioning/decision_tree.py_in
+++ b/src/ports/postgres/modules/recursive_partitioning/decision_tree.py_in
@@ -1040,10 +1040,12 @@ def _get_bins_grps(
         grp_to_col_to_row = dict((grp_key, dict(
             (row['colname'], row['levels']) for row in items))
             for grp_key, items in groupby(all_levels, key=itemgetter('grp_key')))
-
     if cat_features:
-        cat_items_list = [rows[col] for col in cat_features
-                          for grp_key, rows in grp_to_col_to_row.items()]
+        cat_items_list = []
+        for grp_key, rows in grp_to_col_to_row.items():
+            for col in cat_features:
+                if col in rows:
+                    cat_items_list.append(rows[col])
         cat_n = [len(i) for i in cat_items_list]
         cat_origin = [item for subl in cat_items_list for item in subl]
         grp_key_cat=[grp_key for grp_key in grp_to_col_to_row]


### PR DESCRIPTION
JIRA: MADLIB-928

Random forest filters out a feature if it has the same value for every row. If grouping is enabled this filer is applied per group. However _get_bins_grps function did not consider a case where different groups have different features. The commit fixes this issue as well as a typo in one of the related functions.