### PR TITLE
Path: Handling multiple expressions in partition_expr

### DIFF
--- a/src/ports/postgres/modules/utilities/path.py_in
+++ b/src/ports/postgres/modules/utilities/path.py_in
@@ -37,7 +37,6 @@ from validate_args import quote_ident
 
 m4_changequote(`<!', `!>')
 
-
 def path(schema_madlib, source_table, output_table, partition_expr,
          order_expr, pattern_expr, symbol_expr, agg_func,
          persist_rows=None, **kwargs):
@@ -264,13 +263,13 @@ def path(schema_madlib, source_table, output_table, partition_expr,
         plpy.execute(build_multiple_matched_rows)
         quoted_split_p_cols = [quote_ident(i) for i in split_p_cols]
         p_col_orig_name_str = ','.join(
-            [i + " AS " + j for i, j in zip(p_col_names, quoted_split_p_cols)])
+            [i + " AS " + j for i, j in zip(split_p_cols, quoted_split_p_cols)])
 
         if agg_func:
             plpy.execute("""
                 CREATE TABLE {output_table} AS
                    SELECT
-                        {as_partition_expr},
+                        {p_col_orig_name_str},
                         {match_id_name},
                         {agg_func}
                    FROM {matched_rows}
@@ -286,7 +285,6 @@ def path(schema_madlib, source_table, output_table, partition_expr,
         plpy.execute("DROP TABLE IF EXISTS " + input_with_id)
     return result
 # ------------------------------------------------------------------------------
-
 
 def _validate(source_table, output_table, partition_expr, order_expr,
               pattern_expr, symbol_expr, agg_func, persist_rows):

--- a/src/ports/postgres/modules/utilities/test/path.sql_in
+++ b/src/ports/postgres/modules/utilities/test/path.sql_in
@@ -81,7 +81,7 @@ SELECT * FROM weblog ORDER BY event_timestamp ASC;
 SELECT path(
      '"Weblog"',              -- Name of the table
      '"Path_output"',         -- Table name to store the path results
-     'user_id',             -- Partition expression to group the data table
+     'user_id, age_group > 1, income_group > 1',             -- Partition expression to group the data table
      'event_timestamp ASC',         -- Order expression to sort the tuples of the data table
      'I:="Click_event"=0 AND purchase_event=0, Click:="Click_event"=1 AND purchase_event=0, Conv:=purchase_event=1',    -- Definition of various symbols used in the pattern definition
      'I(click){1}(CONV){1}',        -- Definition of the path pattern to search for


### PR DESCRIPTION
JIRA: MADLIB-1003

The various expressions in the partition_expr parameter are now
quoted and renamed. These expressions were not renamed earlier,
which led to an error when there were multiple expressions in the
parameter. Renaming them using ' AS ' fixes this issue.
This commit also includes an update to the install check, which
now includes multiple expressions in partition_expr.