### PR TITLE
Sessionize function: Handling NULL for partition_expr

### DIFF
--- a/src/ports/postgres/modules/utilities/sessionize.py_in
+++ b/src/ports/postgres/modules/utilities/sessionize.py_in
@@ -28,7 +28,7 @@ m4_changequote(`<!', `!>')
 
 
 def sessionize(schema_madlib, source_table, output_table, partition_expr,
-               time_stamp, max_time, output_cols=None, create_view=None, **kwargs):
+               time_stamp, max_time, output_cols, create_view, **kwargs):
     """
         Perform sessionization over a sequence of rows.
 
@@ -39,16 +39,21 @@ def sessionize(schema_madlib, source_table, output_table, partition_expr,
         @param partition_expr: str, Expression to partition (group) the input data
         @param time_stamp: str, The time stamp column name that is used for sessionization calculation
         @param max_time: interval, Delta time between subsequent events to define a session
-        @param output_cols: str, a valid postgres SELECT expression
+        @param output_cols: str, a valid postgres SELECT expression (default '*')
         @param create_view: boolean, indicates if the output is a view or a table with name
                     specified by output_table (default TRUE):
                     TRUE - create view
                     FALSE - materialize results into a table
     """
     with MinWarning("error"):
+        if not partition_expr:
+            partition_expr = "1 = 1"
         _validate(source_table, output_table, partition_expr, time_stamp, max_time)
+        # Checking for 'None' too since create_view and output_cols could be
+        # explicitly set to NULL by the user.
         table_or_view = 'VIEW' if create_view or create_view is None else 'TABLE'
-        output_cols = '*' if output_cols is None else output_cols
+        # Empty string ('') for output_cols is also set to default value '*'
+        output_cols = '*' if not output_cols or output_cols is None else output_cols
 
         # If the output_cols has '*' as one of the elements, expand it to
         # include all columns in the source table. The following list
@@ -120,99 +125,86 @@ def sessionize_help_message(schema_madlib, message, **kwargs):
     """
     Help message for sessionize function
     """
-    help_string = """
-------------------------------------------------------------
-                        SUMMARY
-------------------------------------------------------------
+    summary_string = """
+-----------------------------------------------------------------------------------
+                                    SUMMARY
+-----------------------------------------------------------------------------------
 Functionality: Sessionize
 
-The goal of the MADlib sessionize function is to perform sessionization over
-a time-series based data.
+The MADlib sessionize function performs time-oriented session reconstruction on a 
+data set comprising a sequence of events. A defined period of inactivity indicates 
+the end of one session and beginning of the next session.
 
-------------------------------------------------------------
-                        USAGE
-------------------------------------------------------------
+For more details on function usage:
+    SELECT {schema_madlib}.sessionize('usage');
+
+For a small example on using the function:
+    SELECT {schema_madlib}.sessionize('example');
+    """.format(schema_madlib=schema_madlib)
+
+    usage_string = """
+-----------------------------------------------------------------------------------
+                                    USAGE
+-----------------------------------------------------------------------------------
 SELECT {schema_madlib}.sessionize(
-    'source_table',     -- str, Name of the table
-    'output_table',     -- str, Table name to store the Sessionization results
+    'source_table',     -- str, Name of the source table that contains the data to
+                        -- be sessionized
+    'output_table',     -- str, Name of the output view or table
     'partition_expr',   -- str, Partition expression to group the data table
-    'time_stamp'        -- str, The time stamp column name that is used for sessionization calculation
-    'max_time'          -- interval, Delta time between subsequent events to define a session
-    'output_cols'       -- str, An optional valid postgres SELECT expression for the output table/view (default *)
-    'create_view'       -- boolean, Optional parameter to specify if output is a view or materilized to a table (default True)
+    'time_stamp'        -- str, The time stamp column name that is used for
+                        -- sessionization calculation
+    'max_time'          -- interval, Delta time between subsequent events to define
+                        -- a session
+    'output_cols'       -- str, An optional valid postgres SELECT expression for the
+                        -- output table/view (default *)
+    'create_view'       -- boolean, Optional parameter to specify if output is a 
+                        -- view or materilized to a table (default True)
 );
+    """.format(schema_madlib=schema_madlib)
 
-------------------------------------------------------------
-                        EXAMPLE
-------------------------------------------------------------
+    example_string = """
+-----------------------------------------------------------------------------------
+                                    EXAMPLE
+-----------------------------------------------------------------------------------
 - Create an input data set:
 
 DROP TABLE IF EXISTS eventlog;
 CREATE TABLE eventlog (event_timestamp TIMESTAMP,
             user_id INT,
-            old_session_id INT,
             page TEXT,
-            revenue FLOAT,
-            row INT);
+            revenue FLOAT);
 INSERT INTO eventlog VALUES
-('04/15/2015 01:03:0.5', 100821, 100, 'LANDING', 0, 1),
-('04/15/2015 01:03:50', 100821, 100, 'WINE', 0, 1),
-('04/15/2015 01:04:10', 100821, 100, 'CHECKOUT', 39, 1),
-('04/15/2015 01:04:15', 100821, 101, 'WINE', 0, 1),
-('04/15/2015 01:05:00', 100821, 100, 'WINE', 0, 1),
-('04/15/2015 01:07:00', 100821, 100, 'CHECKOUT', 39, 1),
-('04/15/2015 02:06:00', 100821, 101, 'WINE', 0, 1),
-('04/15/2015 02:06:10', 100821, 101, 'WINE', 0, 1),
-('04/15/2015 02:06:20', 100821, 101, 'WINE', 0, 1),
-('04/15/2015 02:06:30', 100821, 101, 'WINE', 0, 1),
-('04/15/2015 02:07:00', 100821, 101, 'WINE', 0, 1),
-('04/15/2015 01:15:00', 101121, 102, 'LANDING', 0, 1),
-('04/15/2015 01:16:00', 101121, 102, 'WINE', 0, 1),
-('04/15/2015 01:18:00', 101121, 102, 'CHECKOUT', 15, 1),
-('04/15/2015 01:19:00', 101121, 102, 'LANDING', 0, 1),
-('04/15/2015 01:21:00', 101121, 102, 'HELP', 0, 1),
-(NULL, 101121, 102, 'LANDING', 0, 1),
-(NULL, 101121, 102, 'HELP', 0, 1),
-('04/15/2015 01:24:00', 101121, 102, 'WINE', 0, 1),
-('04/15/2015 01:26:00', 101121, 102, 'CHECKOUT', 23, 1),
-('04/15/2015 02:21:00', 101121, 102, 'HELP', 0, 1),
-('04/15/2015 02:24:00', 101121, 102, 'WINE', 0, 1),
-('04/15/2015 02:26:00', 101121, 102, 'CHECKOUT', 23, 1),
-('04/15/2015 02:15:00', 101331, 103, 'LANDING', 0, 1),
-('04/15/2015 02:16:00', 101331, 103, 'WINE', 0, 1),
-('04/15/2015 02:18:00', 101331, 103, 'HELP', 0, 1),
-('04/15/2015 02:20:00', 101331, 103, 'WINE', 0, 1),
-('04/15/2015 02:21:00', 101331, 103, 'CHECKOUT', 16, 1),
-('04/15/2015 02:22:00', 101443, 104, 'BEER', 0, 1),
-('04/15/2015 02:25:00', 101443, 104, 'CHECKOUT', 12, 1),
-('04/15/2015 02:29:00', 101881, 105, 'LANDING', 0, 1),
-('04/15/2015 02:30:00', 101881, 105, 'BEER', 0, 1),
-('04/15/2015 01:05:00', 102201, 106, 'LANDING', 0, 1),
-('04/15/2015 01:06:00', 102201, 106, 'HELP', 0, 1),
-('04/15/2015 01:09:00', 102201, 106, 'LANDING', 0, 1),
-('04/15/2015 02:15:00', 102201, 107, 'WINE', 0, 1),
-('04/15/2015 02:16:00', 102201, 107, 'BEER', 0, 1),
-('04/15/2015 02:17:00', 102201, 107, 'WINE', 0, 1),
-('04/15/2015 02:18:00', 102871, 108, 'BEER', 0, 1),
-('04/15/2015 02:19:00', 102871, 108, 'WINE', 0, 1),
-('04/15/2015 02:22:00', 102871, 108, 'CHECKOUT', 21, 1),
-('04/15/2015 02:25:00', 102871, 108, 'LANDING', 0, 1),
-(NULL, 103711, 109, 'BEER', 0, 1),
-(NULL, 103711, 109, 'LANDING', 0, 1),
-(NULL, 103711, 109, 'WINE', 0, 1),
-('04/15/2016 02:17:00', 103711, 109, 'BEER', 0, 1),
-('04/15/2016 02:18:00', 103711, 109, 'LANDING', 0, 1),
-('04/15/2016 02:19:00', 103711, 109, 'WINE', 0, 1);
+('04/15/2015 02:19:00', 101331, 'CHECKOUT', 16), 
+('04/15/2015 02:17:00', 202201, 'WINE', 0), 
+('04/15/2015 03:18:00', 202201, 'BEER', 0), 
+('04/15/2015 01:03:00', 100821, 'LANDING', 0), 
+('04/15/2015 01:04:00', 100821, 'WINE', 0), 
+('04/15/2015 01:05:00', 100821, 'CHECKOUT', 39), 
+('04/15/2015 02:06:00', 100821, 'WINE', 0), 
+('04/15/2015 02:09:00', 100821, 'WINE', 0), 
+('04/15/2015 02:15:00', 101331, 'LANDING', 0), 
+('04/15/2015 02:16:00', 101331, 'WINE', 0), 
+('04/15/2015 02:17:00', 101331, 'HELP', 0), 
+('04/15/2015 02:18:00', 101331, 'WINE', 0), 
+('04/15/2015 02:29:00', 201881, 'LANDING', 0), 
+('04/15/2015 02:30:00', 201881, 'BEER', 0), 
+('04/15/2015 01:05:00', 202201, 'LANDING', 0),
+('04/15/2015 01:06:00', 202201, 'HELP', 0), 
+('04/15/2015 01:09:00', 202201, 'LANDING', 0), 
+('04/15/2015 02:15:00', 202201, 'WINE', 0), 
+('04/15/2015 02:16:00', 202201, 'BEER', 0), 
+('04/15/2015 03:19:00', 202201, 'WINE', 0), 
+('04/15/2015 03:22:00', 202201, 'CHECKOUT', 21);
 
-- Sessionize the table for each user_id, and obtain only the user_id, with partition expression,
-event_timestamp and session_id:
+- Sessionize the table for each user_id, and obtain only the user_id, with partition
+expression, event_timestamp and session_id:
 
 SELECT {schema_madlib}.sessionize(
  'eventlog',            -- Name of input table
  'sessionize_output',   -- Table name to store sessionized results
  'user_id',             -- Partition input table by session
  'event_timestamp',     -- Order partitions in input table by time
- '0:3:0'                -- Events within a window of this time unit (180 seconds) must be in the same session
+ '0:30:0'               -- Use 30 minute time out to define sessions
  );
 
 - View the output table containing the session IDs:
@@ -221,23 +213,39 @@ SELECT * FROM sessionize_output;
 
 DROP VIEW sessionize_output;
 
-- Sessionize the table for each user_id, and materialize all columns from source table into an output table:
+- Sessionize the table for each user_id, and materialize all columns from
+source table into an output table:
+
 SELECT {schema_madlib}.sessionize(
  'eventlog',                 -- Name of input table
  'sessionize_output',        -- Table name to store sessionized results
- 'user_id',                  -- Partition input table by session
+ 'user_id < 200000',         -- Partition input table by session
  'event_timestamp',          -- Order partitions in input table by time
- '180',                      -- Events within a window of this time unit (180 seconds) must be in the same session
- 'user_id, event_timestamp', -- Preseve only user_id and event_timestamp columns, along with the session id column
+ '180',                      -- Use 3 minutes (180 seconds) to define sessions
+ 'event_timestamp, user_id, user_id < 200000 AS "Department-A1"', 
+                             -- Select only the required columns, along with the
+                             -- session id column that is selected by default
  'false'                     -- Materialize results into a table, and not a view
  );
 
 - View the output table containing the session IDs:
 
-SELECT eventlog.*, sessionize_output.session_id FROM eventlog INNER JOIN sessionize_output ON
-(eventlog.user_id=sessionize_output.user_id AND eventlog.event_timestamp=sessionize_output.event_timestamp);
+SELECT * FROM sessionize_output WHERE "Department-A1"='TRUE';
 
 DROP TABLE sessionize_output;
-    """
+    """.format(schema_madlib=schema_madlib)
 
-    return help_string.format(schema_madlib=schema_madlib)
+    help_string = summary_string
+
+    if not message:
+        return summary_string
+    elif message.lower() in ('usage', 'help', '?'):
+        return usage_string
+    elif message.lower() == 'example':
+        return example_string
+    else:
+        return """
+No such option. Use "SELECT {schema_madlib}.sessionize()" for help.
+        """.format(schema_madlib=schema_madlib)
+    
+    return help_string

--- a/src/ports/postgres/modules/utilities/sessionize.py_in
+++ b/src/ports/postgres/modules/utilities/sessionize.py_in
@@ -247,5 +247,3 @@ DROP TABLE sessionize_output;
         return """
 No such option. Use "SELECT {schema_madlib}.sessionize()" for help.
         """.format(schema_madlib=schema_madlib)
-    
-    return help_string

--- a/src/ports/postgres/modules/utilities/sessionize.sql_in
+++ b/src/ports/postgres/modules/utilities/sessionize.sql_in
@@ -292,7 +292,7 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.sessionize(
     max_time    INTERVAL,
     output_cols VARCHAR
 ) RETURNS void AS $$
-    SELECT MADLIB_SCHEMA.sessionize($1, $2, $3, $4, $5, $6, NULL);
+    SELECT MADLIB_SCHEMA.sessionize($1, $2, $3, $4, $5, $6, True);
 $$ LANGUAGE SQL
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 
@@ -303,7 +303,7 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.sessionize(
     time_stamp  VARCHAR,
     max_time    INTERVAL
 ) RETURNS void AS $$
-    SELECT MADLIB_SCHEMA.sessionize($1, $2, $3, $4, $5, NULL, NULL);
+    SELECT MADLIB_SCHEMA.sessionize($1, $2, $3, $4, $5, '*', True);
 $$ LANGUAGE SQL
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 


### PR DESCRIPTION
JIRA: MADLIB-1001

Changes here now set partition_expr to partition across the whole table
if it is originally set to NULL or '' by the user. This is in line with
how path handles partition_expr. Additionally, if output_expr has NULL
or '' as its value, it is set to '*', which is its default value. Finally,
the create_view param is also set to its default value True if NULL.
This commit also contains some formatting changes to the online help.

@iyerr3 @fmcquillan99 