### PR TITLE
Correct the version used in MADlib rpm installation

### DIFF
--- a/deploy/postflight.sh
+++ b/deploy/postflight.sh
@@ -2,8 +2,6 @@
 
 # $0 - Script Path, $1 - Package Path, $2 - Target Location, and $3 - Target Volumn
 
-MADLIB_VERSION=1.9.1
-
 find $2/usr/local/madlib/bin -type d -exec cp -RPf {} $2/usr/local/madlib/old_bin \; 2>/dev/null
 find $2/usr/local/madlib/bin -depth -type d -exec rm -r {} \; 2>/dev/null
 

--- a/deploy/rpm_post.sh
+++ b/deploy/rpm_post.sh
@@ -4,6 +4,8 @@ find $RPM_INSTALL_PREFIX/madlib/bin -depth -type d -exec rm -r {} \; 2>/dev/null
 find $RPM_INSTALL_PREFIX/madlib/doc -type d -exec cp -RPf {} $RPM_INSTALL_PREFIX/madlib/old_doc \; 2>/dev/null
 find $RPM_INSTALL_PREFIX/madlib/doc -depth -type d -exec rm -r {} \; 2>/dev/null
 
-ln -nsf $RPM_INSTALL_PREFIX/madlib/Versions/%{_madlib_version} $RPM_INSTALL_PREFIX/madlib/Current
+MADLIB_VERSION_HYPHEN=%{_madlib_version}
+MADLIB_VERSION_NO_HYPHEN="${MADLIB_VERSION_HYPHEN/_dev/-dev}"
+ln -nsf $RPM_INSTALL_PREFIX/madlib/Versions/$MADLIB_VERSION_NO_HYPHEN $RPM_INSTALL_PREFIX/madlib/Current
 ln -nsf $RPM_INSTALL_PREFIX/madlib/Current/bin $RPM_INSTALL_PREFIX/madlib/bin
 ln -nsf $RPM_INSTALL_PREFIX/madlib/Current/doc $RPM_INSTALL_PREFIX/madlib/doc


### PR DESCRIPTION
Installing MADlib from an RPM creates a soft link for madpack.
The version number in the soft link contained '_dev' instead of
'-dev', which was introduced when MADlib version was changed to
1.10.0-dev. gppkg does not like an '-' in the RPM file name,
while the semantic versioning requires a '-' in the MADlib version.

@iyerr3 