### PR TITLE
Encode categorical variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,9 +212,9 @@ include(OSXUtils)
 # -- Add subdirectories --------------------------------------------------------
 
 add_subdirectory(src)
-if(CMAKE_COMPILER_IS_GNUCC AND CMAKE_COMPILER_IS_GNUCXX)
-    add_subdirectory(doc) #e.g., Clang/Clang++ does not work
-endif(CMAKE_COMPILER_IS_GNUCC AND CMAKE_COMPILER_IS_GNUCXX)
+add_subdirectory(doc)
+# if(CMAKE_COMPILER_IS_GNUCC AND CMAKE_COMPILER_IS_GNUCXX)
+# endif(CMAKE_COMPILER_IS_GNUCC AND CMAKE_COMPILER_IS_GNUCXX)
 add_subdirectory(deploy)
 
 # -- Install path for specific madlib version ----------------------------------

--- a/doc/mainpage.dox.in
+++ b/doc/mainpage.dox.in
@@ -111,7 +111,7 @@ complete matrix stored as a distributed table.
             @defgroup grp_pca_project Principal Component Projection
         @}
 
-        @defgroup grp_data_prep Encoding Categorical Variables
+        @defgroup grp_encode_categorical Encoding Categorical Variables
         @ingroup grp_datatrans
 
         @defgroup grp_pivot Pivot
@@ -255,9 +255,14 @@ Interface and implementation are subject to change.
 @}
 
 @defgroup grp_deprecated Deprecated Modules
-@{A collection of deprecated modules. @}
-
+@brief A collection of deprecated modules. These functions will be removed in the
+next major version (2.0).
+@{
     @defgroup grp_mlogreg Multinomial Logistic Regression
     @ingroup grp_deprecated
+
+    @defgroup grp_indicator Coding systems for categorical variables
+    @ingroup grp_deprecated
+@}
 
 */

--- a/doc/mainpage.dox.in
+++ b/doc/mainpage.dox.in
@@ -255,8 +255,8 @@ Interface and implementation are subject to change.
 @brief A collection of deprecated modules. These functions will be removed in the
 next major version (2.0).
 @{
-    @defgroup grp_mlogreg Multinomial Logistic Regression
     @defgroup grp_indicator Create Indicator Variables
+    @defgroup grp_mlogreg Multinomial Logistic Regression
 @}
 
 */

--- a/doc/mainpage.dox.in
+++ b/doc/mainpage.dox.in
@@ -181,13 +181,10 @@ complete matrix stored as a distributed table.
         @defgroup grp_random_forest Random Forest
         @ingroup grp_tree
 
-
-
 @defgroup grp_tsa Time Series Analysis
 @{A collection of methods to analyze time series data. @}
     @defgroup grp_arima ARIMA
     @ingroup grp_tsa
-
 
 @defgroup grp_unsupervised Unsupervised Learning
 @{A collection of methods for unsupervised learning tasks @}
@@ -259,10 +256,7 @@ Interface and implementation are subject to change.
 next major version (2.0).
 @{
     @defgroup grp_mlogreg Multinomial Logistic Regression
-    @ingroup grp_deprecated
-
-    @defgroup grp_indicator Coding systems for categorical variables
-    @ingroup grp_deprecated
+    @defgroup grp_indicator Create Indicator Variables
 @}
 
 */

--- a/src/ports/postgres/modules/utilities/create_indicators.py_in
+++ b/src/ports/postgres/modules/utilities/create_indicators.py_in
@@ -128,6 +128,9 @@ def indicator_variables_help(schema_madlib, message, **kwargs):
     """
     if not message:
         help_string = """
+WARNING: This function has been deprecated in favor of the new
+'encode_categorical_variables' function.
+
 -----------------------------------------------------------------------
                             SUMMARY
 -----------------------------------------------------------------------

--- a/src/ports/postgres/modules/utilities/create_indicators.py_in
+++ b/src/ports/postgres/modules/utilities/create_indicators.py_in
@@ -1,14 +1,16 @@
 """
-@file data_preparation.py_in
+@file create_indicators.py_in
 
-@brief Marginal Effects with Interactions: Contains the main interface function
+@brief Contains the main interface function
 and other functions that are common to the various methods and related to
 database constructs.
 
-@namespace marginal
+@namespace create_indicators
 """
 import plpy
+from control import MinWarning
 from utilities import _assert
+from utilities import get_distribution_policy
 from utilities import split_quoted_delimited_str
 from utilities import strip_end_quotes
 from validate_args import table_exists
@@ -18,43 +20,15 @@ from validate_args import _get_table_schema_names
 from validate_args import get_first_schema
 
 m4_changequote(`<!', `!>')
-
-
-def get_distribution_policy(schema_madlib, source_table):
-    """ Return a list of columns that define the distribution policy of table
-    Args:
-        @param source_table
-
-    Returns:
-        List of str.
-    """
-    _, table_name = _get_table_schema_names(source_table)
-    schema_name = get_first_schema(source_table)
-    dist_attr = plpy.execute("""
-    SELECT array_agg(pga.attname) as dist_attr
-    FROM (
-        SELECT gdp.localoid,
-                 CASE
-                     WHEN ( ARRAY_UPPER(gdp.attrnums, 1) > 0 ) THEN
-                        UNNEST(gdp.attrnums)
-                     ELSE NULL
-                 END AS attnum
-            FROM gp_distribution_policy gdp
-        ) AS distkey
-        INNER JOIN pg_class AS pgc
-        ON distkey.localoid = pgc.oid AND pgc.relname = '{table_name}'
-        INNER JOIN pg_namespace pgn
-        ON pgc.relnamespace = pgn.oid AND pgn.nspname = '{schema_name}'
-        LEFT OUTER JOIN pg_attribute pga
-        ON distkey.attnum = pga.attnum AND distkey.localoid = pga.attrelid
-    """.format(table_name=table_name, schema_name=schema_name))[0]["dist_attr"]
-    return dist_attr
-#------------------------------------------------------------------------------
+IS_POSTGRES = m4_ifdef(<!__POSTGRESQL__!>, <!True!>, <!False!>)
+# -----------------------------------------------------------------------
+# Deprecated functions corresponding to "create_indicators.sql_in"
+# -----------------------------------------------------------------------
 
 
 def create_indicator_variables(schema_madlib, source_table, out_table,
-                 categorical_cols, distributed_by=None,
-                 keep_null=False, **kwargs):
+                               categorical_cols, distributed_by=None,
+                               keep_null=False, **kwargs):
     """
     Helper function that can be used to create dummy coding for
     categorical variables.
@@ -65,50 +39,54 @@ def create_indicator_variables(schema_madlib, source_table, out_table,
         @param categorical_cols   A string, comma separated column names for
                             for categorical variables
     """
-    cols = split_quoted_delimited_str(categorical_cols)
-    validate_dummy_coding(source_table, out_table, cols)
+    with MinWarning('warning'):
+        plpy.warning("This function has been deprecated. "
+                     "Please use `encode_categorical_variables` for encoding categoricals.")
+        cols = split_quoted_delimited_str(categorical_cols)
+        validate_dummy_coding(source_table, out_table, cols)
 
-    sql_list = ["CREATE TABLE " + out_table + " AS (SELECT *"]
-    for col in cols:
-        col_no_quotes = strip_end_quotes(col.strip())
-        distinct_values = plpy.execute(
-            "SELECT {col} AS value FROM {source_table} "
-            "GROUP BY {col} ORDER BY {col}".
-            format(col=col, source_table=source_table))
-        distinct_values = [strip_end_quotes(item['value']) for item in distinct_values]
-        null_wrap_case_str = ""
-        null_wrap_end_str = ""
-        if not keep_null and None in distinct_values:
-            null_wrap_case_str = "CASE WHEN \"{col}\" is NULL THEN NULL ELSE "
-            null_wrap_end_str = "END"
-        case_str = ("({wrap_case} "
-                    "CASE WHEN \"{{col}}\" = '{{value}}' THEN 1 ELSE 0 END "
-                    "{wrap_end})".
-                    format(wrap_case=null_wrap_case_str,
-                           wrap_end=null_wrap_end_str))
-        sql_list.append(
-            ", " +
-            ', '.join("{case_str} as \"{{col}}_{{value}}\"".
-                      format(case_str=case_str).
-                      format(col=col_no_quotes, value=str(value))
-                      for value in distinct_values if value is not None))
-        if keep_null and None in distinct_values:
-            sql_list.append(", (CASE WHEN \"{0}\" IS NULL THEN 1 ELSE 0 END) "
-                            "as \"{0}_NULL\"".format(col_no_quotes))
-    sql_list.append(" FROM " + source_table + ") ")
-    m4_ifdef(<!__POSTGRESQL__!>, <!!>, <!
-    if distributed_by:
-        dist_str = distributed_by
-    else:
-        dist_str = ','.join(['"%s"'%i for i in get_distribution_policy(schema_madlib, source_table)
-                             if i is not None])
-    if dist_str:
-        sql_list.append("distributed by (" + dist_str + ")")
-    else:
-        sql_list.append("distributed randomly")
-    !>)
-    plpy.execute(''.join(sql_list))
-    return None
+        sql_list = ["CREATE TABLE " + out_table + " AS (SELECT *"]
+        for col in cols:
+            col_no_quotes = strip_end_quotes(col.strip())
+            distinct_values = plpy.execute(
+                "SELECT {col} AS value FROM {source_table} "
+                "GROUP BY {col} ORDER BY {col}".
+                format(col=col, source_table=source_table))
+            distinct_values = [strip_end_quotes(item['value']) for item in distinct_values]
+            null_wrap_case_str = ""
+            null_wrap_end_str = ""
+            if not keep_null and None in distinct_values:
+                null_wrap_case_str = "CASE WHEN \"{col}\" is NULL THEN NULL ELSE "
+                null_wrap_end_str = "END"
+            case_str = ("({wrap_case} "
+                        "CASE WHEN \"{{col}}\" = '{{value}}' THEN 1 ELSE 0 END "
+                        "{wrap_end})".
+                        format(wrap_case=null_wrap_case_str,
+                               wrap_end=null_wrap_end_str))
+            sql_list.append(
+                ", " +
+                ', '.join("{case_str} as \"{{col}}_{{value}}\"".
+                          format(case_str=case_str).
+                          format(col=col_no_quotes, value=str(value))
+                          for value in distinct_values if value is not None))
+            if keep_null and None in distinct_values:
+                sql_list.append(", (CASE WHEN \"{0}\" IS NULL THEN 1 ELSE 0 END) "
+                                "as \"{0}_NULL\"".format(col_no_quotes))
+        sql_list.append(" FROM " + source_table + ") ")
+
+        if IS_POSTGRES:
+            if distributed_by:
+                dist_str = distributed_by
+            else:
+                dist_str = ','.join(['"%s"'%i
+                                     for i in get_distribution_policy(source_table)
+                                     if i is not None])
+            if dist_str:
+                sql_list.append("distributed by (" + dist_str + ")")
+            else:
+                sql_list.append("distributed randomly")
+        plpy.execute(''.join(sql_list))
+        return None
 # ---------------------------------------------------------------
 
 
@@ -133,7 +111,7 @@ def validate_dummy_coding(source_table, out_table, cols):
     _assert(columns_exist_in_table(source_table, cols),
             "Not all columns from {0} present in source table ({1})"
             .format(cols, source_table))
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
 
 def indicator_variables_help(schema_madlib, message, **kwargs):

--- a/src/ports/postgres/modules/utilities/create_indicators.sql_in
+++ b/src/ports/postgres/modules/utilities/create_indicators.sql_in
@@ -1,6 +1,6 @@
  /* ----------------------------------------------------------------------- *//**
  *
- * @file data_preparation.sql_in
+ * @file create_indicators.sql_in
  *
  * @brief SQL functions for dummy coding categorical variables
  * @date June 2014
@@ -13,8 +13,7 @@ m4_include(`SQLCommon.m4')
 
 
 /**
-@addtogroup grp_data_prep
-
+@addtogroup grp_indicator
 <div class="toc"><b>Contents</b>
 <ul>
 <li><a href="#categorical">Coding systems for categorical variables</a></li>
@@ -204,7 +203,7 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.create_indicator_variables(
     keep_null            BOOLEAN,
     distributed_by       TEXT
 ) RETURNS VOID AS $$
-    PythonFunction(utilities, data_preparation, create_indicator_variables)
+    PythonFunction(utilities, create_indicators, create_indicator_variables)
 $$ LANGUAGE plpythonu
 m4_ifdef(<!__HAS_FUNCTION_PROPERTIES__!>, <!MODIFIES SQL DATA!>, <!!>);
 !>)
@@ -227,7 +226,7 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.create_indicator_variables(
     categorical_cols     TEXT,
     keep_null		     BOOLEAN
 ) RETURNS VOID AS $$
-    PythonFunction(utilities, data_preparation, create_indicator_variables)
+    PythonFunction(utilities, create_indicators, create_indicator_variables)
 $$ LANGUAGE plpythonu
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 
@@ -244,7 +243,7 @@ m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.create_indicator_variables(
     message VARCHAR
 ) RETURNS VARCHAR AS $$
-    PythonFunction(utilities, data_preparation, indicator_variables_help)
+    PythonFunction(utilities, create_indicators, indicator_variables_help)
 $$ LANGUAGE plpythonu IMMUTABLE
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `CONTAINS SQL', `');
 

--- a/src/ports/postgres/modules/utilities/create_indicators.sql_in
+++ b/src/ports/postgres/modules/utilities/create_indicators.sql_in
@@ -14,6 +14,10 @@ m4_include(`SQLCommon.m4')
 
 /**
 @addtogroup grp_indicator
+
+\warning <em> This version of encoding categorical variables has been deprecated.
+The new module with more capability can be found here \ref grp_encode_categorical</em>
+
 <div class="toc"><b>Contents</b>
 <ul>
 <li><a href="#categorical">Coding systems for categorical variables</a></li>

--- a/src/ports/postgres/modules/utilities/encode_categorical.py_in
+++ b/src/ports/postgres/modules/utilities/encode_categorical.py_in
@@ -180,13 +180,11 @@ class CategoricalEncoder(object):
                            " is an invalid numeric value".format(val_str))
             return val
 
-        plpy.info("Top values = " + str(self.top))
         if self.top:
             # top can be a mapping between col name and a value or ...
             out_param = extract_keyvalue_params(self.top,
                                                 allow_duplicates=False,
                                                 lower_case_names=False)
-            plpy.info(out_param)
             if not out_param:
                 # ... a global value (without =) that applies to all columns
                 val = _cast_validate_top(self.top)
@@ -397,14 +395,16 @@ class CategoricalEncoder(object):
         else:
             col_to_type = {}
             features = []
+            ignored_cols = []
             for col in self._categorical_cols:
                 col_type = get_expr_type(col, self.source_table).lower()
                 if col_type in self._cat_types:
                     features.append(col)
                     col_to_type[col] = col_type
                 else:
-                    plpy.warning("Encoding categorical: Ignoring ({0}) since "
-                                 "it is not a categorical type".format(col))
+                    ignored_cols.append(col)
+        plpy.warning("Encoding categorical: Ignoring non-categorical columns ({0})".
+                     format(','.join(ignored_cols)))
         return features, col_to_type
     # -------------------------------------------------------------------------
 

--- a/src/ports/postgres/modules/utilities/encode_categorical.py_in
+++ b/src/ports/postgres/modules/utilities/encode_categorical.py_in
@@ -24,6 +24,7 @@
 
 """
 from itertools import count
+from bisect import bisect
 
 import plpy
 from control import MinWarning
@@ -422,6 +423,11 @@ class CategoricalEncoder(object):
         here is to compute top values only for requested columns and use
         distinct values for others.
         """
+        def _cum_sum(values, start=0):
+            for v in values:
+                start += v
+                yield start
+
         top_val_sql_list = []
         for col in self._output_cols:
             if not self.encode_null:
@@ -450,12 +456,11 @@ class CategoricalEncoder(object):
             col, ordered_values, ordered_freq = [each_col_data[i]
                                                  for i in ('col_name', 'value', 'freq')]
             # drop reference from distinct values
-            if (col in self._value_to_drop):
-                drop_val = self._value_to_drop[col]
-                if drop_val in ordered_values:
-                    drop_index = ordered_values.index(drop_val)
-                    ordered_values.pop(drop_index)
-                    ordered_freq.pop(drop_index)
+            if (col in self._value_to_drop and
+                    self._value_to_drop[col] in ordered_values):
+                drop_index = ordered_values.index(self._value_to_drop[col])
+                ordered_values.pop(drop_index)
+                ordered_freq.pop(drop_index)
 
             if not ordered_values:
                 plpy.error("Encoding categorical error: "
@@ -472,17 +477,8 @@ class CategoricalEncoder(object):
                 else:
                     # ..., top < 1 is considered a percent of total count
                     threshold = int(math.ceil(top_arg * sum(ordered_freq)))
-                    covered_frac = 0
-                    for i, freq in enumerate(ordered_freq):
-                        # iterate ordered frequencies to find the point
-                        # at which cumsum(freq) goes over the threshold
-                        if covered_frac > threshold:
-                            k = i
-                            break
-                        else:
-                            covered_frac += freq
-                    else:
-                        k = i  # max k is len(ordered_values) - 1
+                    cum_freq = list(_cum_sum(ordered_freq))
+                    k = bisect(cum_freq, threshold, 0, len(ordered_values)-2) + 1
 
                 top_distinct_values[col] = ordered_values[:k]
                 if k < len(ordered_values):
@@ -531,7 +527,7 @@ class CategoricalEncoder(object):
                     dv.remove(None)
             else:
                 null_col_name = '"{c}_isnull"'.format(c=strip_end_quotes(col.strip()))
-                col_contains_null = col_values_data[null_col_name]
+                col_contains_null = self._get_quoted_unquoted(col_values_data, null_col_name)
                 if col_contains_null and None not in dv:
                     dv.append(None)
 
@@ -540,7 +536,8 @@ class CategoricalEncoder(object):
                            "No distinct values found for {0} or "
                            "all distinct values dropped as per function arguments"
                            "(value_to_drop, encode_null)".format(col))
-            distinct_values[col] = list(sorted(dv))
+
+            distinct_values[col] = dv
         return distinct_values
 # ------------------------------------------------------------------------------
 

--- a/src/ports/postgres/modules/utilities/encode_categorical.py_in
+++ b/src/ports/postgres/modules/utilities/encode_categorical.py_in
@@ -403,8 +403,9 @@ class CategoricalEncoder(object):
                     col_to_type[col] = col_type
                 else:
                     ignored_cols.append(col)
-        plpy.warning("Encoding categorical: Ignoring non-categorical columns ({0})".
-                     format(','.join(ignored_cols)))
+            if ignored_cols:
+                plpy.warning("Encoding categorical: Ignoring non-categorical columns ({0})".
+                             format(','.join(ignored_cols)))
         return features, col_to_type
     # -------------------------------------------------------------------------
 

--- a/src/ports/postgres/modules/utilities/encode_categorical.py_in
+++ b/src/ports/postgres/modules/utilities/encode_categorical.py_in
@@ -1,0 +1,629 @@
+# coding=utf-8
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Please refer to the encode_categorical.sql_in file for the documentation
+
+"""
+@file encode_categorical.py_in
+
+"""
+from itertools import count
+
+import plpy
+from control import MinWarning
+
+from utilities import _assert
+from utilities import strip_end_quotes
+from utilities import split_quoted_delimited_str
+from utilities import extract_keyvalue_params
+from utilities import add_postfix
+from utilities import is_platform_pg
+
+from validate_args import input_tbl_valid, output_tbl_valid, is_var_valid
+from validate_args import unquote_ident, quote_ident
+from validate_args import get_expr_type, get_cols_and_types
+
+import math
+
+# If there are more than 1600 columns for the output table,
+# it might lead to a database error.
+MAX_OUTPUT_COLUMN_COUNT = 1600
+
+# If a column name has more than 63 characters it gets trimmed automatically,
+# which may cause an exception. Enable the output dictionary in this case.
+MAX_COLUMN_LENGTH = 63
+
+
+class CategoricalEncoder(object):
+    """Encoding class to encode categorical variables"""
+    def __init__(self,
+                 schema_madlib, source_table, output_table, categorical_cols,
+                 categorical_cols_to_exclude=None,
+                 row_id=None,
+                 top=None,
+                 value_to_drop=None,
+                 keep_null=False,
+                 array_output=False,
+                 output_dictionary=False,
+                 distributed_by=None,
+                 **kwargs):
+        super(CategoricalEncoder, self).__init__()
+        self.schema_madlib = schema_madlib
+        self.source_table = source_table
+        self.output_table = output_table
+        self.categorical_cols = categorical_cols
+        self.categorical_cols_to_exclude = categorical_cols_to_exclude
+        self.row_id = row_id
+        self.top = top
+        self.value_to_drop = value_to_drop
+        self.keep_null = keep_null
+        self.array_output = array_output
+        self.output_dictionary = output_dictionary
+        self.distributed_by = distributed_by
+
+        self._name_others_col = "_MISC__"
+        self._array_out_name = "__encoded_variables__"
+
+        # create new parameters after validating and parsing inputs
+        # (order of below statements is relevant)
+        self._parse_parameters()
+        self._validate_parameters()
+
+        self._output_cols, self._col_to_type = self._get_cols_to_encode()
+        if not self._output_cols:
+            plpy.error("Encoding categorical: No categorical columns available "
+                       "to encode (or all have been excluded)")
+
+        # _parse_dictlike_parameters uses _output_cols and has to be below
+        # _get_cols_to_encode
+        self._parse_dictlike_parameters()
+    # ----------------------------------------------------------------------
+
+    def build_output_table(self):
+        if self._top:
+            distinct_values = self._get_top_values()
+        else:
+            distinct_values = self._get_distinct_values()
+        categorical_col_str = self._build_encoding_str(distinct_values)
+        if self._output_dictionary:
+            self._build_output_dictionary(distinct_values)
+        if self._distributed_by:
+            distribution_str = 'DISTRIBUTED BY ({0})'.format(', '.join(self._distributed_by))
+        else:
+            distribution_str = ''
+
+        if self._row_id_cols:
+            other_cols = ', '.join(self._row_id_cols)
+        else:
+            all_cols = [k for k, v in self._all_cols_types]
+            other_cols = ', '.join([c for c in all_cols
+                                    if (c not in self._output_cols and
+                                        unquote_ident(c) not in self._output_cols)])
+
+        if self.array_output:
+            categorical_col_str = ("ARRAY[{0}] AS {1}".
+                                   format(categorical_col_str,
+                                          self._array_out_name))
+        out_sql = """
+            CREATE TABLE {out} AS (
+                SELECT
+                    {other_cols},
+                    {cols}
+                FROM
+                    {src}
+                )
+            {dist}
+            """.format(out=self.output_table,
+                       other_cols=other_cols,
+                       cols=categorical_col_str,
+                       src=self.source_table,
+                       dist=distribution_str)
+        plpy.execute(out_sql)
+    # -------------------------------------------------------------------------
+
+    def _parse_parameters(self):
+        # columns to encode
+        if not self.categorical_cols or self.categorical_cols.strip() == '*':
+            self._categorical_cols = []
+        else:
+            self._categorical_cols = split_quoted_delimited_str(self.categorical_cols)
+        self._categorical_cols_to_exclude = split_quoted_delimited_str(self.categorical_cols_to_exclude)
+
+        # columns that determine the index for output table
+        self._row_id_cols = split_quoted_delimited_str(self.row_id)
+
+        # flag to build a dictionary table
+        self._output_dictionary = True if self.array_output else self.output_dictionary
+
+        # how to distribute the output table (for distributed platforms)
+        if not is_platform_pg():
+            if self.distributed_by:
+                self._distributed_by = split_quoted_delimited_str(self.distributed_by.strip())
+            else:
+                self._distributed_by = self._row_id_cols if self._row_id_cols else []
+        else:
+            self._distributed_by = []
+    # -------------------------------------------------------------------------
+
+    def _parse_dictlike_parameters(self):
+        def _cast_validate_top(val_str):
+            # each value of top can be either a float in (0.0, 1.0) or an integer
+            try:
+                val = float(val_str)
+                _assert(0 < val,
+                        "Encoding categorical error: top value should be positive")
+                if val >= 1:
+                    # if val >= 1 then it should be input as a valid integer
+                    # (e.g. 2 is valid but 2.0 is not)
+                    _assert(val_str.isdigit(),
+                            "Encoding categorical error: top value should "
+                            "be an integer if greater than or equal to 1")
+                    val = int(val_str)
+            except ValueError:
+                plpy.error("Encoding categorical error: top value ({0})"
+                           " is an invalid numeric value".format(val_str))
+            return val
+
+        if self.top:
+            # top can be a mapping between col name and a value or ...
+            out_param = extract_keyvalue_params(self.top, allow_duplicates=False)
+            if not out_param:
+                # ... a global value (without =) that applies to all columns
+                val = _cast_validate_top(self.top)
+                out_param = dict([(i, val) for i in self._output_cols])
+            else:
+                for k in out_param:
+                    out_param[k] = _cast_validate_top(out_param[k])
+            self._top = out_param
+        else:
+            self._top = {}
+
+        if self.value_to_drop:
+            # value_to_drop can be a mapping between col name and a value or ...
+            out_param = extract_keyvalue_params(self.value_to_drop, allow_duplicates=False)
+            if not out_param:
+                # ... a global value (without =) that applies to all columns
+                out_param = dict([(i, str(self.value_to_drop)) for i in self._output_cols])
+            self._value_to_drop = out_param
+        else:
+            self._value_to_drop = {}
+    # -------------------------------------------------------------------------
+
+    def _validate_parameters(self):
+        input_tbl_valid(self.source_table, "Encoding categorical")
+        output_tbl_valid(self.output_table, "Encoding categorical")
+        output_tbl_valid(add_postfix(self.output_table, "_dictionary"), "Encoding categorical")
+        if self._categorical_cols:
+            _assert(is_var_valid(self.source_table, ','.join(self._categorical_cols)),
+                    "Encoding categorical: Not all columns from ({0}) present in source table ({1})"
+                    .format(self._categorical_cols, self.source_table))
+        if self._row_id_cols:
+            _assert(is_var_valid(self.source_table, ','.join(self._row_id_cols)),
+                    "Encoding categorical: Not all columns from ({0}) present in source table ({1})"
+                    .format(self._row_id_cols, self.source_table))
+    # ------------------------------------------------------------------------------
+
+    def _is_col_name_long(self, col_to_values):
+        col_len = []
+        for col, values in col_to_values.items():
+            # Max col name length calculation:
+            #       the name of column (col) +
+            #       name of longest value in column (item) +
+            #       underscore (1)
+            values_len = []
+            for v in values:
+                if v:
+                    if not isinstance(v, (list, tuple)):
+                        values_len.append(len(str(v)))
+                    else:
+                        values_len.append(len(self._name_others_col))
+            col_len.append(len(col) + max(values_len) + 1)
+        return max(col_len) > MAX_COLUMN_LENGTH
+    # -------------------------------------------------------------------------
+
+    def _get_quoted_unquoted(self, col_dict, col):
+        """Special get function to check for quoted and unquoted col names
+           in the given dictionary,
+           since user input is not guaranteed to follow quote_ident rules
+
+           It is assumed that 'col' is originally quoted - the end quotes
+           are stripped to obtain the unquoted form.
+        """
+        return col_dict.get(col,
+                            col_dict.get(
+                                quote_ident(col),
+                                col_dict.get(
+                                    unquote_ident(col),
+                                    None)))
+    # -------------------------------------------------------------------------
+
+    def _build_encoding_str(self, col_to_values):
+        """ Build string to create categorical columns
+
+        Returns:
+           str. The string that goes into the select clause of a query to obtain
+                categorical column encodings
+        """
+        def _build_case_stmt(col, v, seq):
+            """ Return a CASE statement that compares 'col' with the value v
+
+            If v is a list then col is compared to be any one of the
+            elements in v (with special handling for NULL value).
+            """
+            col_no_quotes = strip_end_quotes(col.strip())
+            if isinstance(v, (list, tuple)):
+                # all values collected in a list are to be treated as a single
+                # categorical factor
+                if v:
+                    non_null_v_str = ','.join(["'%s'" % (i) for i in v if i is not None])
+                    if non_null_v_str:
+                        value_str = "IN ({0})".format(non_null_v_str)
+                        if None in v:
+                            value_str += "OR {0} IS NULL".format(col)
+                    else:
+                        value_str = "IS NULL"
+                else:
+                    return ''
+                v_type = list
+            elif v is None:
+                value_str = "IS NULL"
+                v_type = None
+            else:
+                # assume v is a string if not list/tuple and not None
+                value_str = "= '{v}'".format(v=str(v))
+                v_type = str
+
+            if not self.array_output:
+                # array_output = True implies all the case outputs will be wrapped
+                # as an array, hence not requiring an alias for each case
+                if not self._output_dictionary:
+                    value_names = {None: 'NULL',
+                                   list: self._name_others_col,
+                                   str: strip_end_quotes(v)}
+                    alias = 'AS "{0}_{1}"'.format(col_no_quotes, value_names[v_type])
+                else:
+                    alias = 'AS "{0}_{1}"'.format(col_no_quotes, seq)
+            else:
+                alias = ""
+            return ("(CASE WHEN ({col} {value_str}) "
+                    "THEN 1 ELSE 0 END)::INTEGER {alias}".
+                    format(col=col, value_str=value_str, alias=alias))
+
+        self._output_dictionary = (self._output_dictionary or
+                                   self._is_col_name_long(col_to_values))
+        col_switch_list = []
+        for col in self._output_cols:
+            value_switch_list = [_build_case_stmt(col, v, i + 1)
+                                 for i, v in enumerate(col_to_values[col])]
+            # value_switch_list could have '' strings or empty lists which
+            # need to be filtered out before adding to the case switch list
+            col_switch_list.append(','.join([i for i in value_switch_list if i]))
+        return ',\n'.join(col_switch_list)
+
+    # ----------------------------------------------------------------------
+
+    def _build_output_dictionary(self, col_to_values):
+        """ Create a mapping between column names in output table and their
+        corresponding meaning"""
+
+        def _get_value_name(v):
+            if v is None:
+                return "NULL"
+            elif isinstance(v, (list, tuple)):
+                return ",".join([_get_value_name(i) for i in v])
+            else:
+                return str(v)
+
+        dict_tbl_name = add_postfix(self.output_table, "_dictionary")
+        plpy.execute("""
+            CREATE TABLE {tbl} (
+                encoded_column_name TEXT,
+                index               INTEGER,
+                variable            TEXT,
+                value               TEXT
+            )
+        """.format(tbl=dict_tbl_name))
+        global_seq = count(1)
+        for col, values in col_to_values.items():
+            local_seq = count(1)
+            col_no_quotes = strip_end_quotes(col)
+            if self.array_output:
+                encoded_col_name = "__encoded_variables__"
+                seq = global_seq
+            else:
+                encoded_col_name = '"{col_no_quotes}_{seq}"'
+                seq = local_seq
+            insert_template = "('%s', {seq}, '{col}', '{value_str}'::TEXT)" % (encoded_col_name)
+            insert_values = [insert_template.
+                             format(col=col,
+                                    col_no_quotes=col_no_quotes,
+                                    seq=next(seq),
+                                    value_str=_get_value_name(v))
+                             for v in values]
+            plpy.execute("""INSERT INTO {tbl} VALUES {insert_str} """.
+                         format(tbl=dict_tbl_name,
+                                insert_str=',\n'.join(insert_values)))
+    # ----------------------------------------------------------------------
+
+    def _find_cat_features(self):
+        self._all_cols_types = get_cols_and_types(self.source_table)
+
+        # any column belonging to the following types are considered categorical
+        int_types = ['integer', 'smallint']
+        text_types = ['text', 'varchar', 'character varying', 'char', 'character']
+        boolean_types = ['boolean']
+        self._cat_types = set(int_types + text_types + boolean_types)
+
+        self._cat_features = [c for (c, t) in self._all_cols_types
+                              if t in self._cat_types]
+    # -------------------------------------------------------------------------
+
+    def _get_cols_to_encode(self):
+        """ Expand '*' syntax and exclude some categorical columns
+
+        We also exclude from row_id columns
+        """
+        self._find_cat_features()
+
+        # include the quoted name and the unquoted name in exclusion set
+        # to allow user to provide either form
+        exclude_set = set(self._categorical_cols_to_exclude + self._row_id_cols)
+        exclude_set |= set(quote_ident(i)
+                           for i in self._categorical_cols_to_exclude + self._row_id_cols)
+
+        if not self._categorical_cols:
+            features = [f for f in self._cat_features if f not in exclude_set]
+            col_to_type = dict([(c, get_expr_type(c, self.source_table))
+                                for c in features])
+        else:
+            col_to_type = {}
+            features = []
+            for col in self._categorical_cols:
+                col_type = get_expr_type(col, self.source_table).lower()
+                if col_type in self._cat_types:
+                    features.append(col)
+                    col_to_type[col] = col_type
+        return features, col_to_type
+    # -------------------------------------------------------------------------
+
+    def _get_top_values(self):
+        """ Get the top values for each column.
+
+        Note: this function computes the frequencies for values of each column
+        even if that column is not part of the 'top' argument. An improvement
+        here is to compute top values only for requested columns and use
+        distinct values for others.
+        """
+        top_val_sql_list = []
+        for col in self._output_cols:
+            if not self.keep_null:
+                filter_str = 'WHERE {col} IS NOT NULL'.format(col=col)
+            else:
+                filter_str = ''
+            # get value distribution for each column independently
+            top_val_sql_list.append("""
+                SELECT
+                    '{col}' as col_name,
+                    array_agg(f order by c desc) as value,
+                    array_agg(c order by c desc) as freq
+                FROM (
+                    SELECT {col}::text as f, count(*)::integer as c
+                    FROM {tbl}
+                    {filter_str}
+                    GROUP BY {col}
+               ) q
+            """.format(col=col, tbl=self.source_table, filter_str=filter_str))
+        top_values = plpy.execute('\n UNION ALL \n'.join(top_val_sql_list))
+
+        # top_values is now a list of dictionary, each element
+        # giving the frequency of the values in a column
+        top_distinct_values = {}
+        for each_col_data in top_values:
+            col, ordered_values, ordered_freq = [each_col_data[i]
+                                                 for i in ('col_name', 'value', 'freq')]
+            # drop reference from distinct values
+            if (col in self._value_to_drop):
+                drop_val = self._value_to_drop[col]
+                if drop_val in ordered_values:
+                    drop_index = ordered_values.index(drop_val)
+                    ordered_values.pop(drop_index)
+                    ordered_freq.pop(drop_index)
+
+            if not ordered_values:
+                plpy.error("Encoding categorical error: "
+                           "No top values found for {0} or "
+                           "all values dropped as per function arguments"
+                           "(value_to_drop, keep_null)".format(col))
+
+            if col in self._top:
+                # for each column find at which point does the top 'k' values occur
+                top_arg = self._top[col]
+                if top_arg >= 1:
+                    # top >= 1 is considered a integer count of values to pick ...
+                    k = int(top_arg)
+                else:
+                    # ..., top < 1 is considered a percent of total count
+                    threshold = int(math.ceil(top_arg * sum(ordered_freq)))
+                    covered_frac = 0
+                    for i, freq in enumerate(ordered_freq):
+                        # iterate ordered frequencies to find the point
+                        # at which cumsum(freq) goes over the threshold
+                        if covered_frac > threshold:
+                            k = i
+                            break
+                        else:
+                            covered_frac += freq
+                    else:
+                        k = i  # max k is len(ordered_values) - 1
+
+                top_distinct_values[col] = ordered_values[:k]
+                if k < len(ordered_values):
+                    # putting this into an if check avoids empty list
+                    # at the end when k >= actual number of values
+                    top_distinct_values[col] += [list(ordered_values[k:])]
+            else:
+                # need all values for this column since no top provided
+                top_distinct_values[col] = ordered_values
+        return top_distinct_values
+    # -------------------------------------------------------------------------
+
+    def _get_distinct_values(self):
+        """ Find distinct values of each categorical column
+        """
+        array_agg_str = ',\n'.join('array_agg(DISTINCT {c}) AS {c_quoted}'.
+                                   format(c=c, c_quoted=quote_ident(c))
+                                   for c in self._output_cols)
+
+        if self.keep_null:
+            # Some platforms don't include NULL values as part of the
+            # array_agg(DISTINCT ...). Below checks explicitly for NULL values
+            null_str = ', ' + ',\n'.join(
+                'bool_or(CASE WHEN {c} IS NULL THEN True ELSE False END)'
+                ' AS "{c_}_isnull"'.format(c=c, c_=strip_end_quotes(c.strip()))
+                for c in self._output_cols)
+        else:
+            null_str = ''
+        col_values_data = plpy.execute("SELECT {0} {1} FROM {2}".
+                                       format(array_agg_str,
+                                              null_str,
+                                              self.source_table))[0]
+
+        # Collect the distinct values (possibly including null) for every column
+        distinct_values = {}
+        for col in self._output_cols:
+            dv = [str(i) if i is not None else i for i in col_values_data[col]]
+            # drop reference from distinct values
+            if (col in self._value_to_drop and self._value_to_drop[col] in dv):
+                dv.remove(self._value_to_drop[col])
+
+            # check for NULL values
+            if not self.keep_null:
+                if None in dv:
+                    # ignore NULL if keep_null = False
+                    dv.remove(None)
+            else:
+                null_col_name = '"{c}_isnull"'.format(c=strip_end_quotes(col.strip()))
+                col_contains_null = col_values_data[null_col_name]
+                if col_contains_null and None not in dv:
+                    dv.append(None)
+
+            if not dv:
+                plpy.error("Encoding categorical error: "
+                           "No distinct values found for {0} or "
+                           "all distinct values dropped as per function arguments"
+                           "(value_to_drop, keep_null)".format(col))
+            distinct_values[col] = list(sorted(dv))
+        return distinct_values
+# ------------------------------------------------------------------------------
+
+
+def encode_categorical_variables(
+        schema_madlib, source_table, output_table, categorical_cols,
+        categorical_cols_to_exclude=None,
+        row_id=None,
+        top=None,
+        value_to_drop=None,
+        keep_null=False,
+        array_output=None,
+        output_dictionary=False,
+        distributed_by=None,
+        **kwargs):
+    """
+    Main function to encode categorical variables
+    Args:
+        @param source_table:str, Name of table containing categorical variable
+        @param output_table:str, Name of table to output dummy variables
+        @param categorical_cols:str, Comma-separated list of column names to dummy code (can be '*')
+        @param categorical_cols_to_exclude:str, Comma-separated list of column names to exclude (if categorical_cols = '*')
+        @param row_id: str, Columns from source table to index output table
+        @param top: str, Parameter to include only top values of a categorical variable
+        @param value_to_drop: str, Parameter to set reference column in dummy coding
+        @param keep_null: bool, If True, NULL is treated as a categorical value
+        @param array_output: bool, Parameter to determine if output should be in an array or columns
+        @param output_dictionary: bool, If True columns names are simplified and
+                    a separate mapping table is created to understand the names
+        @param distributed_by: str, Comma-separated list of column names to use for distribution of output
+    """
+    with MinWarning('warning'):
+        encoder = CategoricalEncoder(schema_madlib, source_table, output_table,
+                                     categorical_cols, categorical_cols_to_exclude,
+                                     row_id, top, value_to_drop, keep_null,
+                                     array_output, output_dictionary,
+                                     distributed_by)
+        encoder.build_output_table()
+    return None
+# ---------------------------------------------------------------
+
+
+def encode_categorical_help(schema_madlib, message, **kwargs):
+    """
+    Help function for encode_categorical_variables
+
+    Args:
+        @param schema_madlib
+        @param message: string, Help message string
+        @param kwargs
+
+    Returns:
+        String. Help/usage information
+    """
+    if not message:
+        help_string = """
+-----------------------------------------------------------------------
+                            SUMMARY
+-----------------------------------------------------------------------
+Provide functionality to create indicator variables from categorical variables
+to be used by regression methods. Categorical variables require special
+attention in regression analysis because, unlike dichotomous or continuous
+variables, they cannot by entered into the regression equation just as they are.
+For example, if you have a variable called race that is coded 1 = Hispanic, 2 =
+Asian 3 = Black 4 = White, then entering race in your regression will look at
+the linear effect of race, which is probably not what you intended. Instead,
+categorical variables like this need to be recoded into a series of indicator
+variables which can then be entered into the regression model.
+
+For more details on function usage:
+    SELECT {madlib}.encode_categorical_variables('usage')
+            """
+    elif message in ['usage', 'help', '?']:
+        help_string = """
+-----------------------------------------------------------------------
+                            USAGE
+-----------------------------------------------------------------------
+
+
+-----------------------------------------------------------------------
+                           OUTPUT
+-----------------------------------------------------------------------
+"""
+    elif message in ['examples', 'example']:
+        help_string = """
+-----------------------------------------------------------------------
+                          EXAMPLES
+-----------------------------------------------------------------------
+
+"""
+    else:
+        help_string = """No such option.
+
+For more details on function usage:
+    SELECT {madlib}.encode_categorical_variables('usage')
+"""
+    return help_string.format(madlib=schema_madlib)
+# ---------------------------------------------------------------------

--- a/src/ports/postgres/modules/utilities/encode_categorical.py_in
+++ b/src/ports/postgres/modules/utilities/encode_categorical.py_in
@@ -58,7 +58,7 @@ class CategoricalEncoder(object):
                  row_id=None,
                  top=None,
                  value_to_drop=None,
-                 keep_null=False,
+                 encode_null=False,
                  array_output=False,
                  output_dictionary=False,
                  distributed_by=None,
@@ -72,7 +72,7 @@ class CategoricalEncoder(object):
         self.row_id = row_id
         self.top = top
         self.value_to_drop = value_to_drop
-        self.keep_null = keep_null
+        self.encode_null = encode_null
         self.array_output = array_output
         self.output_dictionary = output_dictionary
         self.distributed_by = distributed_by
@@ -341,7 +341,8 @@ class CategoricalEncoder(object):
             )
         """.format(tbl=dict_tbl_name))
         global_seq = count(1)
-        for col, values in col_to_values.items():
+        for col in self._output_cols:
+            values = col_to_values[col]
             local_seq = count(1)
             col_no_quotes = strip_end_quotes(col)
             if self.array_output:
@@ -419,7 +420,7 @@ class CategoricalEncoder(object):
         """
         top_val_sql_list = []
         for col in self._output_cols:
-            if not self.keep_null:
+            if not self.encode_null:
                 filter_str = 'WHERE {col} IS NOT NULL'.format(col=col)
             else:
                 filter_str = ''
@@ -456,7 +457,7 @@ class CategoricalEncoder(object):
                 plpy.error("Encoding categorical error: "
                            "No top values found for {0} or "
                            "all values dropped as per function arguments"
-                           "(value_to_drop, keep_null)".format(col))
+                           "(value_to_drop, encode_null)".format(col))
 
             if col in self._top:
                 # for each column find at which point does the top 'k' values occur
@@ -497,7 +498,7 @@ class CategoricalEncoder(object):
                                    format(c=c, c_quoted=quote_ident(c))
                                    for c in self._output_cols)
 
-        if self.keep_null:
+        if self.encode_null:
             # Some platforms don't include NULL values as part of the
             # array_agg(DISTINCT ...). Below checks explicitly for NULL values
             null_str = ', ' + ',\n'.join(
@@ -520,9 +521,9 @@ class CategoricalEncoder(object):
                 dv.remove(self._value_to_drop[col])
 
             # check for NULL values
-            if not self.keep_null:
+            if not self.encode_null:
                 if None in dv:
-                    # ignore NULL if keep_null = False
+                    # ignore NULL if encode_null = False
                     dv.remove(None)
             else:
                 null_col_name = '"{c}_isnull"'.format(c=strip_end_quotes(col.strip()))
@@ -534,7 +535,7 @@ class CategoricalEncoder(object):
                 plpy.error("Encoding categorical error: "
                            "No distinct values found for {0} or "
                            "all distinct values dropped as per function arguments"
-                           "(value_to_drop, keep_null)".format(col))
+                           "(value_to_drop, encode_null)".format(col))
             distinct_values[col] = list(sorted(dv))
         return distinct_values
 # ------------------------------------------------------------------------------
@@ -546,7 +547,7 @@ def encode_categorical_variables(
         row_id=None,
         top=None,
         value_to_drop=None,
-        keep_null=False,
+        encode_null=False,
         array_output=None,
         output_dictionary=False,
         distributed_by=None,
@@ -561,7 +562,7 @@ def encode_categorical_variables(
         @param row_id: str, Columns from source table to index output table
         @param top: str, Parameter to include only top values of a categorical variable
         @param value_to_drop: str, Parameter to set reference column in dummy coding
-        @param keep_null: bool, If True, NULL is treated as a categorical value
+        @param encode_null: bool, If True, NULL is treated as a categorical value
         @param array_output: bool, Parameter to determine if output should be in an array or columns
         @param output_dictionary: bool, If True columns names are simplified and
                     a separate mapping table is created to understand the names
@@ -570,7 +571,7 @@ def encode_categorical_variables(
     with MinWarning('warning'):
         encoder = CategoricalEncoder(schema_madlib, source_table, output_table,
                                      categorical_cols, categorical_cols_to_exclude,
-                                     row_id, top, value_to_drop, keep_null,
+                                     row_id, top, value_to_drop, encode_null,
                                      array_output, output_dictionary,
                                      distributed_by)
         encoder.build_output_table()

--- a/src/ports/postgres/modules/utilities/encode_categorical.py_in
+++ b/src/ports/postgres/modules/utilities/encode_categorical.py_in
@@ -180,9 +180,13 @@ class CategoricalEncoder(object):
                            " is an invalid numeric value".format(val_str))
             return val
 
+        plpy.info("Top values = " + str(self.top))
         if self.top:
             # top can be a mapping between col name and a value or ...
-            out_param = extract_keyvalue_params(self.top, allow_duplicates=False)
+            out_param = extract_keyvalue_params(self.top,
+                                                allow_duplicates=False,
+                                                lower_case_names=False)
+            plpy.info(out_param)
             if not out_param:
                 # ... a global value (without =) that applies to all columns
                 val = _cast_validate_top(self.top)
@@ -193,7 +197,6 @@ class CategoricalEncoder(object):
             self._top = out_param
         else:
             self._top = {}
-
         if self.value_to_drop:
             # value_to_drop can be a mapping between col name and a value or ...
             out_param = extract_keyvalue_params(self.value_to_drop, allow_duplicates=False)
@@ -399,6 +402,9 @@ class CategoricalEncoder(object):
                 if col_type in self._cat_types:
                     features.append(col)
                     col_to_type[col] = col_type
+                else:
+                    plpy.warning("Encoding categorical: Ignoring ({0}) since "
+                                 "it is not a categorical type".format(col))
         return features, col_to_type
     # -------------------------------------------------------------------------
 

--- a/src/ports/postgres/modules/utilities/encode_categorical.py_in
+++ b/src/ports/postgres/modules/utilities/encode_categorical.py_in
@@ -597,15 +597,27 @@ def encode_categorical_help(schema_madlib, message, **kwargs):
 -----------------------------------------------------------------------
                             SUMMARY
 -----------------------------------------------------------------------
-Provide functionality to create indicator variables from categorical variables
-to be used by regression methods. Categorical variables require special
-attention in regression analysis because, unlike dichotomous or continuous
-variables, they cannot by entered into the regression equation just as they are.
-For example, if you have a variable called race that is coded 1 = Hispanic, 2 =
-Asian 3 = Black 4 = White, then entering race in your regression will look at
-the linear effect of race, which is probably not what you intended. Instead,
-categorical variables like this need to be recoded into a series of indicator
-variables which can then be entered into the regression model.
+Categorical variables [1] require special attention in regression analysis
+because, unlike dichotomous or continuous variables, they cannot be entered into
+the regression equation just as they are.  For example, if you have a variable
+called race that is coded with 1=Hispanic, 2=Asian, 3=Black, 4=White, then
+entering race in your regression will look at the linear effect of the race
+variable, which is probably not what you intended. Instead, categorical
+variables like this need to be coded into a series of indicator variables which
+can then be entered into the regression model.  There are a variety of coding
+systems that can be used for coding categorical variables, including one-hot,
+dummy, effects, orthogonal, and Helmert.
+
+We currently support one-hot and dummy coding techniques.
+
+Dummy coding is used when a researcher wants to compare other groups of the
+predictor variable with one specific group of the predictor variable.
+Often, the specific group to compare with is called the reference group.
+
+One-hot encoding is similar to dummy coding except it builds indicator (0/1)
+columns (cast as numeric) for each value of each category.
+Only one of these columns could take on the value 1 for each row (data point).
+There is no reference category for this function.
 
 For more details on function usage:
     SELECT {madlib}.encode_categorical_variables('usage')
@@ -615,17 +627,36 @@ For more details on function usage:
 -----------------------------------------------------------------------
                             USAGE
 -----------------------------------------------------------------------
+SELECT {madlib}.encode_categorical_variables (
+        source_table,                   -- Name of source table
+        output_table,                   -- Name of table to output encoded data
+        categorical_cols,               -- Comma-separated list of columns to encode
+                                        --  (can be *)
+        categorical_cols_to_exclude,    -- (Optional) Columns to exclude if using '*' above
+        row_id,                         -- (Optional) Columns corresponding to
+                                        --  primary keys of source table
+        top,                            -- (Optional) Parameter to encode only top values
+        value_to_drop,                  -- (Optional) Reference value to drop for each column
+        encode_null,                    -- (Optional) Whether NULL should be treated as one of the
+                                        --  values of the categorical variable.
+        array_output,                   -- (Optional) Get all encoded variables in an array
+        output_dictionary,              -- (Optional) Simplify output column naming and provide
+                                        --  a mapping between simple names and meaning
+        distributed_by                  -- (Optional) Columns to use for the distribution policy of
+                                        --   the output table (does not apply for Postgresql)
+        )
 
-
+Refer to online documentation for details on above parameters.
 -----------------------------------------------------------------------
                            OUTPUT
 -----------------------------------------------------------------------
-"""
-    elif message in ['examples', 'example']:
-        help_string = """
------------------------------------------------------------------------
-                          EXAMPLES
------------------------------------------------------------------------
+    If there are index columns in the 'source_table' specified by the parameter
+    'row_id' (see below), then the output table will contain only the index
+    columns 'row_id' and the encoded columns.
+
+    If the parameter 'row_id' is not specified, then all columns from the
+    'source_table', with the exception of the original categorical columns,
+    will be included in the 'output_table'.
 
 """
     else:

--- a/src/ports/postgres/modules/utilities/encode_categorical.py_in
+++ b/src/ports/postgres/modules/utilities/encode_categorical.py_in
@@ -103,8 +103,12 @@ class CategoricalEncoder(object):
         categorical_col_str = self._build_encoding_str(distinct_values)
         if self._output_dictionary:
             self._build_output_dictionary(distinct_values)
+
         if self._distributed_by:
-            distribution_str = 'DISTRIBUTED BY ({0})'.format(', '.join(self._distributed_by))
+            if self._distributed_by[0].lower() == 'randomly':
+                distribution_str = 'DISTRIBUTED RANDOMLY'
+            else:
+                distribution_str = 'DISTRIBUTED BY ({0})'.format(', '.join(self._distributed_by))
         else:
             distribution_str = ''
 

--- a/src/ports/postgres/modules/utilities/encode_categorical.sql_in
+++ b/src/ports/postgres/modules/utilities/encode_categorical.sql_in
@@ -76,7 +76,7 @@ encode_categorical_variables (
         row_id,                         -- Optional
         top,                            -- Optional
         value_to_drop,                  -- Optional
-        keep_null,                      -- Optional
+        encode_null,                      -- Optional
         array_output,                   -- Optional
         output_dictionary,              -- Optional
         distributed_by                  -- Optional

--- a/src/ports/postgres/modules/utilities/encode_categorical.sql_in
+++ b/src/ports/postgres/modules/utilities/encode_categorical.sql_in
@@ -1,0 +1,454 @@
+/* ----------------------------------------------------------------------- *//**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *
+ * @file encode_categorical.sql_in
+ *
+ * @brief SQL functions for encoding categorical variables to numerical values
+ * @date Dec 2016
+ *
+ * @sa Encodes categorical variables to numerical values
+ *
+ *//* ----------------------------------------------------------------------- */
+
+
+m4_include(`SQLCommon.m4')
+
+
+/**
+@addtogroup grp_encode_categorical
+
+<div class="toc"><b>Contents</b>
+<ul>
+<li><a href="#categorical">Coding systems for categorical variables</a></li>
+<li><a href="#examples">Examples</a></li>
+</ul>
+</div>
+
+@brief Provides functions to encode categorical variables
+
+@anchor categorical
+@par Coding systems for categorical variables
+Categorical variables require special attention in regression analysis because,
+unlike dichotomous or continuous variables, they cannot be entered into the
+regression equation just as they are.  For example, if you have a variable
+called race that is coded 1 = Hispanic, 2 = Asian, 3 = Black, 4 = White, then
+entering race in your regression will look at the linear effect of race, which
+is probably not what you intended. Instead, categorical variables like this need
+to be recoded into a series of indicator variables which can then be entered
+into the regression model.  There are a variety of coding systems (also called
+as contrasts) that can be used for coding categorical variables including
+dummy, effects, orthogonal, and helmert coding.
+
+We currently only support the one-hot encoding and dummy coding technique.
+
+Dummy coding is used when a researcher wants to compare other groups of the
+predictor variable with one specific group of the predictor variable.
+Often, the specific group to compare with is called the reference group.
+
+One-hot encoding is similar to dummy coding except it builds indicator (0/1)
+columns (cast as numeric) for each value of each category.
+Only one of these columns could take on the value 1 for each row (data point).
+There is no reference category for this function.
+
+<pre class="syntax">
+encode_categorical_variables (
+        source_table,
+        output_table,
+        categorical_cols,
+        categorical_cols_to_exclude,    -- Optional
+        row_id,                         -- Optional
+        top,                            -- Optional
+        value_to_drop,                  -- Optional
+        keep_null,                      -- Optional
+        array_output,                   -- Optional
+        output_dictionary,              -- Optional
+        distributed_by                  -- Optional
+)
+</pre>
+\b Arguments
+<dl class="arglist">
+    <dt>source_table</dt>
+    <dd>VARCHAR. Name of the source table, containing data for categorical variables.</dd>
+
+    <dt>output_table</dt>
+    <dd>VARCHAR. Name of the result table.
+    Note: If there are index columns in the source_table specified by the parameter
+    <em>row_id</em>, then the output table will contain only the index <em>row_id</em> and the
+    encoded columns.  If the parameter <em>row_id</em> is not specified, then all columns,
+    other than the original encoded columns, from the source_table will be included.
+    </dd>
+
+    <dt>categorical_cols</dt>
+    <dd>VARCHAR. Comma-separated string of column names of categorical variables to encode.
+    Can also be '*' implying all columns are to be encoded (except the ones
+    specified in categorical_cols_to_exclude). Please note that all Boolean,
+    integer and text columns are considered categorical columns and will be
+    encoded for ‘*’ argument.
+    </dd>
+
+    <dt>categorical_cols_to_exclude (optional)</dt>
+    <dd>VARCHAR. Comma-separated string of column names to exclude from the
+    categorical variables to encode. Applicable only if 'categorical_cols' = '*'.
+    </dd>
+
+    <dt>row_id (optional)</dt>
+    <dd>VARCHAR. Comma-separated column name(s) corresponding to the primary key(s) of the
+    source table. This parameter determines the format of the output_table as
+    described above. If 'categorical_cols' = '*', then these columns will be
+    excluded from encoding (but will be included in the output table).
+    </dd>
+
+    <dt>top (optional)</dt>
+    <dd>VARCHAR. default: NULL.  If INTEGER, encodes the top n values
+    by frequency.  If FLOAT in the range (0.0, 1.0), encodes the specified fraction
+    of values by frequency (e.g., 0.1 means top 10%).  Can be specified as a global
+    for all categorical columns, or as a dictionary with separate values for each
+    categorical variable. Set to NULL to encode all levels (values) of all categorical
+    columns.
+    </dd>
+
+    <dt>value_to_drop (optional)</dt>
+    <dd>VARCHAR. Default: NULL.
+
+    - For dummy coding, indicate the desired value (reference) to drop for each
+    categorical variable. The expected input is a comma-separated text
+    containing items of the form `name=value`, where 'name' is the column name
+    and 'value' is the reference value to be dropped. Only one value per variable
+    is allowed.
+
+    - Set to NULL for one-hot encoding (default)
+    </dd>
+
+    <dt>keep_null (optional)</dt>
+    <dd>BOOLEAN. default: FALSE. Whether 'NULL' should be treated as one of the
+    values of the categorical variable. If TRUE, then an indicator
+    variable is created corresponding to the NULL value. If FALSE, then
+    all indicator variables for that tuple will be set to NULL.
+    </dd>
+
+    <dt>array_output (optional)</dt>
+    <dd>VARCHAR. default: NULL.
+
+    This parameter controls the output format of the indicator variables. If NULL,
+    a column is created for each indicator variable. Postgresql limits the
+    number of columns in a table. If the total number of indicator columns, exceeds
+    this limit, then this parameter can be used to combine the indicator columns
+    into an array. The parameter can take following values:
+
+    - Set to '*' to place all indicator variables in a single array. The order of
+    the columns is the same as <em>categorical_cols</em>.
+    - Set to '|' to create a separate array for each categorical column
+    - Set to a comma-separated list of column names to create arrays for only
+    specific columns
+    </dd>
+
+    <dt>output_dictionary (optional)</dt>
+    <dd>BOOLEAN. default: FALSE.
+    This parameter is used to handle auto-generated column names that exceed the
+    PostgreSQL limit of 63 bytes.
+
+    - If TRUE, column names will be set as
+    numerical IDs and will create a dictionary table called <em>output_table</em>_dictionary
+    (<em>output_table</em> appended with <em>_dictionary</em>).
+
+    - If FALSE, will auto-generate column names in the
+    usual way unless the limit of 63 bytes will be exceeded. In this case, a
+    dictionary output file will be created and a message given to the user.
+    </dd>
+
+    <dt>distributed_by (optional)</dt>
+    <dd>VARCHAR. default: NULL. Columns to use for the distribution policy of
+    the output table. When NULL, either 'row_id' is used as distribution policy
+    (when provided), else the distribution policy of 'source_table' will be used.
+    This argument is not available for POSTGRESQL platforms.
+
+    - NULL:  By default, the distribution policy of the source_table will be used.
+    - Comma-separated column names: Column(s) to be used for the distribution key.
+    - randomly: Use random distribution policy (only if there does not exist a column named 'randomly').
+
+    </dd>
+</dl>
+
+@anchor examples
+@examp
+
+-#  Use a subset of the abalone dataset.
+<pre class="example">
+DROP TABLE IF EXISTS abalone;
+CREATE TABLE abalone (
+    sex character varying,
+    length double precision,
+    diameter double precision,
+    height double precision
+);
+COPY abalone (sex, length, diameter, height) FROM stdin WITH DELIMITER '|' NULL as '@';
+M| 0.455 |   0.365 | 0.095
+F| 0.53  |   0.42  | 0.135
+M| 0.35  |   0.265 | 0.09
+F| 0.53  |   0.415 | 0.15
+M| 0.44  |   0.365 | 0.125
+F| 0.545 |   0.425 | 0.125
+I| 0.33  |   0.255 | 0.08
+F| 0.55  |   0.44  | 0.15
+I| 0.425 |   0.30  | 0.095
+F| 0.525 |   0.38  | 0.140
+M| 0.475 |   0.37  | 0.125
+F| 0.535 |   0.405 | 0.145
+M| 0.43  |   0.358 | 0.11
+F| 0.47  |   0.355 | 0.100
+M| 0.49  |   0.38  | 0.135
+F| 0.44  |   0.340 | 0.100
+M| 0.5   |   0.400 | 0.13
+F| 0.565 |   0.44  | 0.155
+I| 0.355 |   0.280 | 0.085
+F| 0.550 |   0.415 | 0.135
+@| 0.475 |   0.37  | 0.125
+\\.
+</pre>
+
+-# Create new table with dummy-coded indicator variables
+<pre class="example">
+drop table if exists abalone_out;
+select madlib.create_indicator_variables ('abalone', 'abalone_out', 'sex');
+select * from abalone_out;
+</pre>
+<pre class="result">
+ sex  | length | diameter | height | sex_F  | sex_I  | sex_M
+&nbsp; -----+--------+----------+--------+--------+--------+-------
+ F    |   0.53 |     0.42 |  0.135 |      1 |      0 |     0
+ F    |   0.53 |    0.415 |   0.15 |      1 |      0 |     0
+ F    |  0.545 |    0.425 |  0.125 |      1 |      0 |     0
+ F    |   0.55 |     0.44 |   0.15 |      1 |      0 |     0
+ F    |  0.525 |     0.38 |   0.14 |      1 |      0 |     0
+ F    |  0.535 |    0.405 |  0.145 |      1 |      0 |     0
+ F    |   0.47 |    0.355 |    0.1 |      1 |      0 |     0
+ F    |   0.44 |     0.34 |    0.1 |      1 |      0 |     0
+ F    |  0.565 |     0.44 |  0.155 |      1 |      0 |     0
+ F    |   0.55 |    0.415 |  0.135 |      1 |      0 |     0
+ M    |  0.455 |    0.365 |  0.095 |      0 |      0 |     1
+ M    |   0.35 |    0.265 |   0.09 |      0 |      0 |     0
+ M    |   0.44 |    0.365 |  0.125 |      0 |      0 |     0
+ I    |   0.33 |    0.255 |   0.08 |      0 |      1 |     0
+ I    |  0.425 |      0.3 |  0.095 |      0 |      1 |     0
+ M    |  0.475 |     0.37 |  0.125 |      0 |      0 |     0
+ M    |   0.43 |    0.358 |   0.11 |      0 |      0 |     0
+ M    |   0.49 |     0.38 |  0.135 |      0 |      0 |     0
+ M    |    0.5 |      0.4 |   0.13 |      0 |      0 |     0
+ I    |  0.355 |     0.28 |  0.085 |      0 |      1 |     0
+ NULL |   0.55 |    0.415 |  0.135 |   NULL |   NULL |  NULL
+</pre>
+
+-# Create indicator variable for 'NULL' value (note the additional column '"sex_NULL"')
+<pre class="example">
+drop table if exists abalone_out;
+select madlib.create_indicator_variables'abalone', 'abalone_out', 'sex', True);
+select * from abalone_out;
+</pre>
+<pre class="result">
+ sex  | length | diameter | height | sex_F  | sex_I  | sex_M | sex_NULL
+&nbsp; ------+--------+----------+--------+--------+--------+-------+-------
+ F    |   0.53 |     0.42 |  0.135 |      1 |      0 |     0 |     0
+ F    |   0.53 |    0.415 |   0.15 |      1 |      0 |     0 |     0
+ F    |  0.545 |    0.425 |  0.125 |      1 |      0 |     0 |     0
+ F    |   0.55 |     0.44 |   0.15 |      1 |      0 |     0 |     0
+ F    |  0.525 |     0.38 |   0.14 |      1 |      0 |     0 |     0
+ F    |  0.535 |    0.405 |  0.145 |      1 |      0 |     0 |     0
+ F    |   0.47 |    0.355 |    0.1 |      1 |      0 |     0 |     0
+ F    |   0.44 |     0.34 |    0.1 |      1 |      0 |     0 |     0
+ F    |  0.565 |     0.44 |  0.155 |      1 |      0 |     0 |     0
+ F    |   0.55 |    0.415 |  0.135 |      1 |      0 |     0 |     0
+ M    |  0.455 |    0.365 |  0.095 |      0 |      0 |     1 |     0
+ M    |   0.35 |    0.265 |   0.09 |      0 |      0 |     0 |     0
+ M    |   0.44 |    0.365 |  0.125 |      0 |      0 |     0 |     0
+ I    |   0.33 |    0.255 |   0.08 |      0 |      1 |     0 |     0
+ I    |  0.425 |      0.3 |  0.095 |      0 |      1 |     0 |     0
+ M    |  0.475 |     0.37 |  0.125 |      0 |      0 |     0 |     0
+ M    |   0.43 |    0.358 |   0.11 |      0 |      0 |     0 |     0
+ M    |   0.49 |     0.38 |  0.135 |      0 |      0 |     0 |     0
+ M    |    0.5 |      0.4 |   0.13 |      0 |      0 |     0 |     0
+ I    |  0.355 |     0.28 |  0.085 |      0 |      1 |     0 |     0
+ NULL |   0.55 |    0.415 |  0.135 |      0 |      0 |     0 |     1
+</pre>
+*/
+
+-------------------------------------------------------------------------
+
+/**
+ * @brief Encode categorical columns using either one-hot encoding or dummy coding
+ *
+ * @param source_table Name of table containing categorical variable
+ * @param output_table Name of table to output dummy variables
+ * @param categorical_cols Comma-separated list of column names to dummy code (can be '*')
+ * @param categorical_cols_to_exclude Comma-separated list of column names to exclude (if categorical_cols = '*')
+ * @param row_id Columns from source table to index output table
+ * @param top Parameter to include only top values of a categorical variable
+ * @param value_to_drop Parameter to set reference column in dummy coding
+ * @param keep_null Boolean to determine the behavior for rows with NULL value
+ * @param array_output Boolean to determine if output should be in an array or columns
+ * @param output_dictionary Boolean to simplify column naming and with a separate
+ *                              mapping table to actual values
+ * @param distributed_by Comma-separated list of column names to use for distribution of output
+ *
+ * @return Void
+ *
+ */
+
+-- We don't create the below function for PostgreSQL since it does not contain a
+-- distribution policy.
+m4_changequote(<!,!>)
+m4_ifdef(<!__POSTGRESQL__!>, <!!>, <!
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.encode_categorical_variables(
+    source_table                    VARCHAR,
+    output_table                    VARCHAR,
+    categorical_cols                VARCHAR,
+    categorical_cols_to_exclude     VARCHAR,
+    row_id                          VARCHAR,
+    top                             VARCHAR,
+    value_to_drop                   VARCHAR,
+    keep_null                       BOOLEAN,
+    array_output                    BOOLEAN,
+    output_dictionary               BOOLEAN,
+    distributed_by                  VARCHAR
+) RETURNS VOID AS $$
+    PythonFunction(utilities, encode_categorical, encode_categorical_variables)
+$$ LANGUAGE plpythonu
+m4_ifdef(<!__HAS_FUNCTION_PROPERTIES__!>, <!MODIFIES SQL DATA!>, <!!>);
+!>)
+m4_changequote(<!`!>, <!'!>)
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.encode_categorical_variables(
+    source_table                    VARCHAR,
+    output_table                    VARCHAR,
+    categorical_cols                VARCHAR,
+    categorical_cols_to_exclude     VARCHAR,
+    row_id                          VARCHAR,
+    top                             VARCHAR,
+    value_to_drop                   VARCHAR,
+    keep_null                       BOOLEAN,
+    array_output                    BOOLEAN,
+    output_dictionary               BOOLEAN
+) RETURNS VOID AS $$
+    PythonFunction(utilities, encode_categorical, encode_categorical_variables)
+$$ LANGUAGE plpythonu
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
+
+-- Overloaded functions --------------------------------------------------------
+-- Default values are set by underlying Python function
+--------------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.encode_categorical_variables(
+    source_table                    VARCHAR,
+    output_table                    VARCHAR,
+    categorical_cols                VARCHAR,
+    categorical_cols_to_exclude     VARCHAR,
+    row_id                          VARCHAR,
+    top                             VARCHAR,
+    value_to_drop                   VARCHAR,
+    keep_null                       BOOLEAN,
+    array_output                    BOOLEAN
+) RETURNS VOID AS $$
+    PythonFunction(utilities, encode_categorical, encode_categorical_variables)
+$$ LANGUAGE plpythonu
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.encode_categorical_variables(
+    source_table                    VARCHAR,
+    output_table                    VARCHAR,
+    categorical_cols                VARCHAR,
+    categorical_cols_to_exclude     VARCHAR,
+    row_id                          VARCHAR,
+    top                             VARCHAR,
+    value_to_drop                   VARCHAR,
+    keep_null                       BOOLEAN
+) RETURNS VOID AS $$
+    PythonFunction(utilities, encode_categorical, encode_categorical_variables)
+$$ LANGUAGE plpythonu
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.encode_categorical_variables(
+    source_table                    VARCHAR,
+    output_table                    VARCHAR,
+    categorical_cols                VARCHAR,
+    categorical_cols_to_exclude     VARCHAR,
+    row_id                          VARCHAR,
+    top                             VARCHAR,
+    value_to_drop                   VARCHAR
+) RETURNS VOID AS $$
+    PythonFunction(utilities, encode_categorical, encode_categorical_variables)
+$$ LANGUAGE plpythonu
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.encode_categorical_variables(
+    source_table                    VARCHAR,
+    output_table                    VARCHAR,
+    categorical_cols                VARCHAR,
+    categorical_cols_to_exclude     VARCHAR,
+    row_id                          VARCHAR,
+    top                             VARCHAR
+) RETURNS VOID AS $$
+    PythonFunction(utilities, encode_categorical, encode_categorical_variables)
+$$ LANGUAGE plpythonu
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.encode_categorical_variables(
+    source_table                    VARCHAR,
+    output_table                    VARCHAR,
+    categorical_cols                VARCHAR,
+    categorical_cols_to_exclude     VARCHAR,
+    row_id                          VARCHAR
+) RETURNS VOID AS $$
+    PythonFunction(utilities, encode_categorical, encode_categorical_variables)
+$$ LANGUAGE plpythonu
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.encode_categorical_variables(
+    source_table                    VARCHAR,
+    output_table                    VARCHAR,
+    categorical_cols                VARCHAR,
+    categorical_cols_to_exclude     VARCHAR
+) RETURNS VOID AS $$
+    PythonFunction(utilities, encode_categorical, encode_categorical_variables)
+$$ LANGUAGE plpythonu
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.encode_categorical_variables(
+    source_table                    VARCHAR,
+    output_table                    VARCHAR,
+    categorical_cols                VARCHAR
+) RETURNS VOID AS $$
+    PythonFunction(utilities, encode_categorical, encode_categorical_variables)
+$$ LANGUAGE plpythonu
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
+
+-- Online help -----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.encode_categorical_variables(
+    message VARCHAR
+) RETURNS VARCHAR AS $$
+    PythonFunction(utilities, encode_categorical, encode_categorical_help)
+$$ LANGUAGE plpythonu IMMUTABLE
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `CONTAINS SQL', `');
+
+--------------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.encode_categorical_variables()
+RETURNS VARCHAR AS $$
+    SELECT MADLIB_SCHEMA.encode_categorical_variables('');
+$$ LANGUAGE sql IMMUTABLE
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `CONTAINS SQL', `');
+--------------------------------------------------------------------------------

--- a/src/ports/postgres/modules/utilities/encode_categorical.sql_in
+++ b/src/ports/postgres/modules/utilities/encode_categorical.sql_in
@@ -31,32 +31,34 @@
 m4_include(`SQLCommon.m4')
 
 
+
 /**
 @addtogroup grp_encode_categorical
 
 <div class="toc"><b>Contents</b>
 <ul>
-<li><a href="#categorical">Coding systems for categorical variables</a></li>
+<li><a href="#categorical">Coding Systems for Categorical Variables</a></li>
 <li><a href="#examples">Examples</a></li>
+<li><a href="#literature">Literature</a></li>
 </ul>
 </div>
 
 @brief Provides functions to encode categorical variables
 
 @anchor categorical
-@par Coding systems for categorical variables
-Categorical variables require special attention in regression analysis because,
+@par Coding Systems for Categorical Variables
+Categorical variables [1] require special attention in regression analysis because,
 unlike dichotomous or continuous variables, they cannot be entered into the
 regression equation just as they are.  For example, if you have a variable
-called race that is coded 1 = Hispanic, 2 = Asian, 3 = Black, 4 = White, then
-entering race in your regression will look at the linear effect of race, which
+called race that is coded with 1=Hispanic, 2=Asian, 3=Black, 4=White, then
+entering race in your regression will look at the linear effect of the race variable, which
 is probably not what you intended. Instead, categorical variables like this need
-to be recoded into a series of indicator variables which can then be entered
-into the regression model.  There are a variety of coding systems (also called
-as contrasts) that can be used for coding categorical variables including
-dummy, effects, orthogonal, and helmert coding.
+to be coded into a series of indicator variables which can then be entered
+into the regression model.  There are a variety of coding systems that can
+be used for coding categorical variables, including
+one-hot, dummy, effects, orthogonal, and Helmert.
 
-We currently only support the one-hot encoding and dummy coding technique.
+We currently support one-hot and dummy coding techniques.
 
 Dummy coding is used when a researcher wants to compare other groups of the
 predictor variable with one specific group of the predictor variable.
@@ -80,27 +82,31 @@ encode_categorical_variables (
         array_output,                   -- Optional
         output_dictionary,              -- Optional
         distributed_by                  -- Optional
-)
+        )
 </pre>
 \b Arguments
 <dl class="arglist">
     <dt>source_table</dt>
-    <dd>VARCHAR. Name of the source table, containing data for categorical variables.</dd>
+    <dd>VARCHAR. Name of the table containing the source categorical data to encode.</dd>
 
     <dt>output_table</dt>
     <dd>VARCHAR. Name of the result table.
-    Note: If there are index columns in the source_table specified by the parameter
-    <em>row_id</em>, then the output table will contain only the index <em>row_id</em> and the
-    encoded columns.  If the parameter <em>row_id</em> is not specified, then all columns,
-    other than the original encoded columns, from the source_table will be included.
+
+    @note
+    If there are index columns in the 'source_table' specified by the parameter
+    'row_id' (see below), then the output table will contain only the index
+    columns 'row_id' and the encoded columns.  If the parameter 'row_id' is
+    not specified, then all columns from the 'source_table', with the
+    exception of the original columns that have been encoded, will be
+    included in the 'output_table'.
     </dd>
 
     <dt>categorical_cols</dt>
     <dd>VARCHAR. Comma-separated string of column names of categorical variables to encode.
-    Can also be '*' implying all columns are to be encoded (except the ones
-    specified in categorical_cols_to_exclude). Please note that all Boolean,
+    Can also be '*' meaning all columns are to be encoded, except the ones
+    specified in 'categorical_cols_to_exclude' and 'row_id'. Please note that all Boolean,
     integer and text columns are considered categorical columns and will be
-    encoded for ‘*’ argument.
+    encoded when ‘*’ is specified for this argument.
     </dd>
 
     <dt>categorical_cols_to_exclude (optional)</dt>
@@ -110,17 +116,23 @@ encode_categorical_variables (
 
     <dt>row_id (optional)</dt>
     <dd>VARCHAR. Comma-separated column name(s) corresponding to the primary key(s) of the
-    source table. This parameter determines the format of the output_table as
-    described above. If 'categorical_cols' = '*', then these columns will be
+    source table. This parameter determines the format of the 'output_table' as
+    described above. If 'categorical_cols' = '*', these columns will be
     excluded from encoding (but will be included in the output table).
+
+    @note
+    If you want to see both the raw categorical variable and its encoded form
+    in the output_table, then include the categorical variable in the 'row_id' parameter.
+    However, this will not work if you specify '*' for the parameter 'categorical_cols',
+    because in this case 'row_id' columns will not be encoded at all.
     </dd>
 
     <dt>top (optional)</dt>
-    <dd>VARCHAR. default: NULL.  If INTEGER, encodes the top n values
-    by frequency.  If FLOAT in the range (0.0, 1.0), encodes the specified fraction
+    <dd>VARCHAR. default: NULL.  If integer, encodes the top n values
+    by frequency.  If float in the range (0.0, 1.0), encodes the specified fraction
     of values by frequency (e.g., 0.1 means top 10%).  Can be specified as a global
-    for all categorical columns, or as a dictionary with separate values for each
-    categorical variable. Set to NULL to encode all levels (values) of all categorical
+    for all categorical columns, or as a dictionary with separate 'top' values for each
+    categorical variable. Set to NULL to encode all levels (values) for all categorical
     columns.
     </dd>
 
@@ -128,35 +140,35 @@ encode_categorical_variables (
     <dd>VARCHAR. Default: NULL.
 
     - For dummy coding, indicate the desired value (reference) to drop for each
-    categorical variable. The expected input is a comma-separated text
-    containing items of the form `name=value`, where 'name' is the column name
-    and 'value' is the reference value to be dropped. Only one value per variable
-    is allowed.
+    categorical variable. Can be specified as a global for all categorical columns,
+    or a comma-separated string containing items of the form 'name=value', where
+    'name' is the column name and 'value' is the reference value to be dropped.
 
     - Set to NULL for one-hot encoding (default)
+
+    @note
+    If you specify both 'value_to_drop' and 'top' parameters,
+    the 'value_to_drop' will be applied first (takes priority),
+    then 'top' will be applied to the remaining values.
     </dd>
 
     <dt>encode_null (optional)</dt>
-    <dd>BOOLEAN. default: FALSE. Whether 'NULL' should be treated as one of the
+    <dd>BOOLEAN. default: FALSE. Whether NULL should be treated as one of the
     values of the categorical variable. If TRUE, then an indicator
     variable is created corresponding to the NULL value. If FALSE, then
-    all indicator variables for that tuple will be set to NULL.
+    all encoded values for that variable will be set to 0.
     </dd>
 
     <dt>array_output (optional)</dt>
-    <dd>VARCHAR. default: NULL.
-
-    This parameter controls the output format of the indicator variables. If NULL,
-    a column is created for each indicator variable. Postgresql limits the
-    number of columns in a table. If the total number of indicator columns, exceeds
-    this limit, then this parameter can be used to combine the indicator columns
-    into an array. The parameter can take following values:
-
-    - Set to '*' to place all indicator variables in a single array. The order of
-    the columns is the same as <em>categorical_cols</em>.
-    - Set to '|' to create a separate array for each categorical column
-    - Set to a comma-separated list of column names to create arrays for only
-    specific columns
+    <dd>BOOLEAN. default: FALSE.  This parameter controls the output format
+    of the indicator variables. If FALSE, a column is created for each indicator
+    variable. PostgreSQL limits the number of columns in a table.
+    If the total number of indicator columns exceeds the limit, then make this
+    parameter TRUE to combine the indicator columns
+    into an array. The order of the array is the same as specified in 'categorical_cols'.
+    A dictionary will be created when 'array_output' is TRUE to define an index into
+    the array.  The dictionary table will be given the name of the 'output_table'
+    appended by '_dictionary'.
     </dd>
 
     <dt>output_dictionary (optional)</dt>
@@ -164,9 +176,9 @@ encode_categorical_variables (
     This parameter is used to handle auto-generated column names that exceed the
     PostgreSQL limit of 63 bytes.
 
-    - If TRUE, column names will be set as
-    numerical IDs and will create a dictionary table called <em>output_table</em>_dictionary
-    (<em>output_table</em> appended with <em>_dictionary</em>).
+    - If TRUE, column names will include numerical IDs and will create a dictionary
+    table called 'output_table_dictionary'
+    ('output_table' appended with '_dictionary').
 
     - If FALSE, will auto-generate column names in the
     usual way unless the limit of 63 bytes will be exceeded. In this case, a
@@ -176,12 +188,12 @@ encode_categorical_variables (
     <dt>distributed_by (optional)</dt>
     <dd>VARCHAR. default: NULL. Columns to use for the distribution policy of
     the output table. When NULL, either 'row_id' is used as distribution policy
-    (when provided), else the distribution policy of 'source_table' will be used.
-    This argument is not available for POSTGRESQL platforms.
+    (when provided), or else the distribution policy of 'source_table' will be used.
+    This argument does not apply to PostgreSQL platforms.
 
     - NULL:  By default, the distribution policy of the source_table will be used.
     - Comma-separated column names: Column(s) to be used for the distribution key.
-    - randomly: Use random distribution policy (only if there does not exist a column named 'randomly').
+    - RANDOMLY: Use random distribution policy (only if there does not exist a column named 'randomly').
 
     </dd>
 </dl>
@@ -189,105 +201,452 @@ encode_categorical_variables (
 @anchor examples
 @examp
 
--#  Use a subset of the abalone dataset.
+-#  Use a subset of the abalone dataset [2]:
 <pre class="example">
 DROP TABLE IF EXISTS abalone;
 CREATE TABLE abalone (
+    id serial,
     sex character varying,
     length double precision,
     diameter double precision,
-    height double precision
+    height double precision,
+    rings int
 );
-COPY abalone (sex, length, diameter, height) FROM stdin WITH DELIMITER '|' NULL as '@';
-M| 0.455 |   0.365 | 0.095
-F| 0.53  |   0.42  | 0.135
-M| 0.35  |   0.265 | 0.09
-F| 0.53  |   0.415 | 0.15
-M| 0.44  |   0.365 | 0.125
-F| 0.545 |   0.425 | 0.125
-I| 0.33  |   0.255 | 0.08
-F| 0.55  |   0.44  | 0.15
-I| 0.425 |   0.30  | 0.095
-F| 0.525 |   0.38  | 0.140
-M| 0.475 |   0.37  | 0.125
-F| 0.535 |   0.405 | 0.145
-M| 0.43  |   0.358 | 0.11
-F| 0.47  |   0.355 | 0.100
-M| 0.49  |   0.38  | 0.135
-F| 0.44  |   0.340 | 0.100
-M| 0.5   |   0.400 | 0.13
-F| 0.565 |   0.44  | 0.155
-I| 0.355 |   0.280 | 0.085
-F| 0.550 |   0.415 | 0.135
-@| 0.475 |   0.37  | 0.125
-\\.
+INSERT INTO abalone (sex, length, diameter, height, rings) VALUES
+('M',    0.455,  0.365,  0.095,  15),
+('M',    0.35,   0.265,  0.09,   7),
+('F',    0.53,   0.42,   0.135,  9),
+('M',    0.44,   0.365,  0.125,  10),
+('I',    0.33,   0.255,  0.08,   7),
+('I',    0.425,  0.3,    0.095,  8),
+('F',    0.53,   0.415,  0.15,   20),
+('F',    0.545,  0.425,  0.125,  16),
+('M',    0.475,  0.37,   0.125,  9),
+(NULL,   0.55,   0.44,   0.15,   19),
+('F',    0.525,  0.38,   0.14,   14),
+('M',    0.43,   0.35,   0.11,   10),
+('M',    0.49,   0.38,   0.135,  11),
+('F',    0.535,  0.405,  0.145,  10),
+('F',    0.47,   0.355,  0.1,    10),
+('M',    0.5,    0.4,    0.13,   12),
+('I',    0.355,  0.28,   0.085,  7),
+('F',    0.44,   0.34,   0.1,    10),
+('M',    0.365,  0.295,  0.08,   7),
+(NULL,   0.45,   0.32,   0.1,    9);
 </pre>
 
--# Create new table with dummy-coded indicator variables
+-# Create new table with one-hot encoding.
+The column 'sex' is replaced by three columns encoding the
+values 'F', 'M' and 'I'. Null values are not encoded by default:
 <pre class="example">
-drop table if exists abalone_out;
-select madlib.create_indicator_variables ('abalone', 'abalone_out', 'sex');
-select * from abalone_out;
+DROP TABLE IF EXISTS abalone_out, abalone_out_dictionary;
+SELECT madlib.encode_categorical_variables (
+        'abalone',                   -- Source table
+        'abalone_out',               -- Output table
+        'sex'                        -- Categorical columns
+        );
+SELECT * FROM abalone_out ORDER BY id;
 </pre>
 <pre class="result">
- sex  | length | diameter | height | sex_F  | sex_I  | sex_M
-&nbsp; -----+--------+----------+--------+--------+--------+-------
- F    |   0.53 |     0.42 |  0.135 |      1 |      0 |     0
- F    |   0.53 |    0.415 |   0.15 |      1 |      0 |     0
- F    |  0.545 |    0.425 |  0.125 |      1 |      0 |     0
- F    |   0.55 |     0.44 |   0.15 |      1 |      0 |     0
- F    |  0.525 |     0.38 |   0.14 |      1 |      0 |     0
- F    |  0.535 |    0.405 |  0.145 |      1 |      0 |     0
- F    |   0.47 |    0.355 |    0.1 |      1 |      0 |     0
- F    |   0.44 |     0.34 |    0.1 |      1 |      0 |     0
- F    |  0.565 |     0.44 |  0.155 |      1 |      0 |     0
- F    |   0.55 |    0.415 |  0.135 |      1 |      0 |     0
- M    |  0.455 |    0.365 |  0.095 |      0 |      0 |     1
- M    |   0.35 |    0.265 |   0.09 |      0 |      0 |     0
- M    |   0.44 |    0.365 |  0.125 |      0 |      0 |     0
- I    |   0.33 |    0.255 |   0.08 |      0 |      1 |     0
- I    |  0.425 |      0.3 |  0.095 |      0 |      1 |     0
- M    |  0.475 |     0.37 |  0.125 |      0 |      0 |     0
- M    |   0.43 |    0.358 |   0.11 |      0 |      0 |     0
- M    |   0.49 |     0.38 |  0.135 |      0 |      0 |     0
- M    |    0.5 |      0.4 |   0.13 |      0 |      0 |     0
- I    |  0.355 |     0.28 |  0.085 |      0 |      1 |     0
- NULL |   0.55 |    0.415 |  0.135 |   NULL |   NULL |  NULL
+  id | length | diameter | height | rings | sex_F | sex_I | sex_M
+----+--------+----------+--------+-------+-------+-------+-------
+  1 |  0.455 |    0.365 |  0.095 |    15 |     0 |     0 |     1
+  2 |   0.35 |    0.265 |   0.09 |     7 |     0 |     0 |     1
+  3 |   0.53 |     0.42 |  0.135 |     9 |     1 |     0 |     0
+  4 |   0.44 |    0.365 |  0.125 |    10 |     0 |     0 |     1
+  5 |   0.33 |    0.255 |   0.08 |     7 |     0 |     1 |     0
+  6 |  0.425 |      0.3 |  0.095 |     8 |     0 |     1 |     0
+  7 |   0.53 |    0.415 |   0.15 |    20 |     1 |     0 |     0
+  8 |  0.545 |    0.425 |  0.125 |    16 |     1 |     0 |     0
+  9 |  0.475 |     0.37 |  0.125 |     9 |     0 |     0 |     1
+ 10 |   0.55 |     0.44 |   0.15 |    19 |     0 |     0 |     0
+ 11 |  0.525 |     0.38 |   0.14 |    14 |     1 |     0 |     0
+ 12 |   0.43 |     0.35 |   0.11 |    10 |     0 |     0 |     1
+ 13 |   0.49 |     0.38 |  0.135 |    11 |     0 |     0 |     1
+ 14 |  0.535 |    0.405 |  0.145 |    10 |     1 |     0 |     0
+ 15 |   0.47 |    0.355 |    0.1 |    10 |     1 |     0 |     0
+ 16 |    0.5 |      0.4 |   0.13 |    12 |     0 |     0 |     1
+ 17 |  0.355 |     0.28 |  0.085 |     7 |     0 |     1 |     0
+ 18 |   0.44 |     0.34 |    0.1 |    10 |     1 |     0 |     0
+ 19 |  0.365 |    0.295 |   0.08 |     7 |     0 |     0 |     1
+ 20 |   0.45 |     0.32 |    0.1 |     9 |     0 |     0 |     0
+(20 rows)
 </pre>
 
--# Create indicator variable for 'NULL' value (note the additional column '"sex_NULL"')
+-# Now include NULL values in encoding (note the additional column 'sex_NULL'):
 <pre class="example">
-drop table if exists abalone_out;
-select madlib.create_indicator_variables'abalone', 'abalone_out', 'sex', True);
-select * from abalone_out;
+DROP TABLE IF EXISTS abalone_out, abalone_out_dictionary;
+SELECT madlib.encode_categorical_variables (
+        'abalone',                   -- Source table
+        'abalone_out',               -- Output table
+        'sex',                       -- Categorical columns
+        NULL,                        -- Categorical columns to exclude
+        NULL,                        -- Index columns
+        NULL,                        -- Top values
+        NULL,                        -- Value to drop for dummy encoding
+        TRUE                         -- Encode nulls
+        );
+SELECT * FROM abalone_out ORDER BY id;
 </pre>
 <pre class="result">
- sex  | length | diameter | height | sex_F  | sex_I  | sex_M | sex_NULL
-&nbsp; ------+--------+----------+--------+--------+--------+-------+-------
- F    |   0.53 |     0.42 |  0.135 |      1 |      0 |     0 |     0
- F    |   0.53 |    0.415 |   0.15 |      1 |      0 |     0 |     0
- F    |  0.545 |    0.425 |  0.125 |      1 |      0 |     0 |     0
- F    |   0.55 |     0.44 |   0.15 |      1 |      0 |     0 |     0
- F    |  0.525 |     0.38 |   0.14 |      1 |      0 |     0 |     0
- F    |  0.535 |    0.405 |  0.145 |      1 |      0 |     0 |     0
- F    |   0.47 |    0.355 |    0.1 |      1 |      0 |     0 |     0
- F    |   0.44 |     0.34 |    0.1 |      1 |      0 |     0 |     0
- F    |  0.565 |     0.44 |  0.155 |      1 |      0 |     0 |     0
- F    |   0.55 |    0.415 |  0.135 |      1 |      0 |     0 |     0
- M    |  0.455 |    0.365 |  0.095 |      0 |      0 |     1 |     0
- M    |   0.35 |    0.265 |   0.09 |      0 |      0 |     0 |     0
- M    |   0.44 |    0.365 |  0.125 |      0 |      0 |     0 |     0
- I    |   0.33 |    0.255 |   0.08 |      0 |      1 |     0 |     0
- I    |  0.425 |      0.3 |  0.095 |      0 |      1 |     0 |     0
- M    |  0.475 |     0.37 |  0.125 |      0 |      0 |     0 |     0
- M    |   0.43 |    0.358 |   0.11 |      0 |      0 |     0 |     0
- M    |   0.49 |     0.38 |  0.135 |      0 |      0 |     0 |     0
- M    |    0.5 |      0.4 |   0.13 |      0 |      0 |     0 |     0
- I    |  0.355 |     0.28 |  0.085 |      0 |      1 |     0 |     0
- NULL |   0.55 |    0.415 |  0.135 |      0 |      0 |     0 |     1
+ id | length | diameter | height | rings | sex_F | sex_I | sex_M | sex_NULL
+----+--------+----------+--------+-------+-------+-------+-------+----------
+  1 |  0.455 |    0.365 |  0.095 |    15 |     0 |     0 |     1 |        0
+  2 |   0.35 |    0.265 |   0.09 |     7 |     0 |     0 |     1 |        0
+  3 |   0.53 |     0.42 |  0.135 |     9 |     1 |     0 |     0 |        0
+  4 |   0.44 |    0.365 |  0.125 |    10 |     0 |     0 |     1 |        0
+  5 |   0.33 |    0.255 |   0.08 |     7 |     0 |     1 |     0 |        0
+  6 |  0.425 |      0.3 |  0.095 |     8 |     0 |     1 |     0 |        0
+  7 |   0.53 |    0.415 |   0.15 |    20 |     1 |     0 |     0 |        0
+  8 |  0.545 |    0.425 |  0.125 |    16 |     1 |     0 |     0 |        0
+  9 |  0.475 |     0.37 |  0.125 |     9 |     0 |     0 |     1 |        0
+ 10 |   0.55 |     0.44 |   0.15 |    19 |     0 |     0 |     0 |        1
+ 11 |  0.525 |     0.38 |   0.14 |    14 |     1 |     0 |     0 |        0
+ 12 |   0.43 |     0.35 |   0.11 |    10 |     0 |     0 |     1 |        0
+ 13 |   0.49 |     0.38 |  0.135 |    11 |     0 |     0 |     1 |        0
+ 14 |  0.535 |    0.405 |  0.145 |    10 |     1 |     0 |     0 |        0
+ 15 |   0.47 |    0.355 |    0.1 |    10 |     1 |     0 |     0 |        0
+ 16 |    0.5 |      0.4 |   0.13 |    12 |     0 |     0 |     1 |        0
+ 17 |  0.355 |     0.28 |  0.085 |     7 |     0 |     1 |     0 |        0
+ 18 |   0.44 |     0.34 |    0.1 |    10 |     1 |     0 |     0 |        0
+ 19 |  0.365 |    0.295 |   0.08 |     7 |     0 |     0 |     1 |        0
+ 20 |   0.45 |     0.32 |    0.1 |     9 |     0 |     0 |     0 |        1
+(20 rows)
 </pre>
+
+-# Encode all categorical variables in the source table.  Also, specify the
+column 'id' as the index (primary key) which changes the output table
+to include only the index and the encoded variables:
+<pre class="example">
+DROP TABLE IF EXISTS abalone_out, abalone_out_dictionary;
+SELECT madlib.encode_categorical_variables (
+        'abalone',                   -- Source table
+        'abalone_out',               -- Output table
+        '*',                         -- Categorical columns
+        NULL,                        -- Categorical columns to exclude
+        'id'                         -- Index columns
+        );
+SELECT * FROM abalone_out ORDER BY id;
+</pre>
+<pre class="result">
+ id | sex_F | sex_I | sex_M | rings_10 | rings_11 | rings_12 | rings_14 | rings_15 | rings_16 | rings_19 | rings_20 | rings_7 | rings_8 | rings_9
+----+-------+-------+-------+----------+----------+----------+----------+----------+----------+----------+----------+---------+---------+---------
+  1 |     0 |     0 |     1 |        0 |        0 |        0 |        0 |        1 |        0 |        0 |        0 |       0 |       0 |       0
+  2 |     0 |     0 |     1 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |       1 |       0 |       0
+  3 |     1 |     0 |     0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |       0 |       0 |       1
+  4 |     0 |     0 |     1 |        1 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |       0 |       0 |       0
+  5 |     0 |     1 |     0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |       1 |       0 |       0
+  6 |     0 |     1 |     0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |       0 |       1 |       0
+  7 |     1 |     0 |     0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |        1 |       0 |       0 |       0
+  8 |     1 |     0 |     0 |        0 |        0 |        0 |        0 |        0 |        1 |        0 |        0 |       0 |       0 |       0
+  9 |     0 |     0 |     1 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |       0 |       0 |       1
+ 10 |     0 |     0 |     0 |        0 |        0 |        0 |        0 |        0 |        0 |        1 |        0 |       0 |       0 |       0
+ 11 |     1 |     0 |     0 |        0 |        0 |        0 |        1 |        0 |        0 |        0 |        0 |       0 |       0 |       0
+ 12 |     0 |     0 |     1 |        1 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |       0 |       0 |       0
+ 13 |     0 |     0 |     1 |        0 |        1 |        0 |        0 |        0 |        0 |        0 |        0 |       0 |       0 |       0
+ 14 |     1 |     0 |     0 |        1 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |       0 |       0 |       0
+ 15 |     1 |     0 |     0 |        1 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |       0 |       0 |       0
+ 16 |     0 |     0 |     1 |        0 |        0 |        1 |        0 |        0 |        0 |        0 |        0 |       0 |       0 |       0
+ 17 |     0 |     1 |     0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |       1 |       0 |       0
+ 18 |     1 |     0 |     0 |        1 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |       0 |       0 |       0
+ 19 |     0 |     0 |     1 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |       1 |       0 |       0
+ 20 |     0 |     0 |     0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |       0 |       0 |       1
+(20 rows)
+</pre>
+
+-# Now let's encode only the top values and group others into a
+miscellaneous bucket column. Top values can be global across all
+columns or specified by column. As an example of the latter, here
+are the top 2 'sex' values and the top 50% of 'rings' values:
+<pre class="example">
+DROP TABLE IF EXISTS abalone_out, abalone_out_dictionary;
+SELECT madlib.encode_categorical_variables (
+        'abalone',                   -- Source table
+        'abalone_out',               -- Output table
+        '*',                         -- Categorical columns
+        NULL,                        -- Categorical columns to exclude
+        'id',                        -- Index columns
+        'sex=2, rings=0.5'           -- Top values
+        );
+SELECT * FROM abalone_out ORDER BY id;
+</pre>
+<pre class="result">
+ id | sex_M | sex_F | sex__MISC__ | rings_10 | rings_7 | rings_9 | rings__MISC__
+----+-------+-------+-------------+----------+---------+---------+---------------
+  1 |     1 |     0 |           0 |        0 |       0 |       0 |             1
+  2 |     1 |     0 |           0 |        0 |       1 |       0 |             0
+  3 |     0 |     1 |           0 |        0 |       0 |       1 |             0
+  4 |     1 |     0 |           0 |        1 |       0 |       0 |             0
+  5 |     0 |     0 |           1 |        0 |       1 |       0 |             0
+  6 |     0 |     0 |           1 |        0 |       0 |       0 |             1
+  7 |     0 |     1 |           0 |        0 |       0 |       0 |             1
+  8 |     0 |     1 |           0 |        0 |       0 |       0 |             1
+  9 |     1 |     0 |           0 |        0 |       0 |       1 |             0
+ 10 |     0 |     0 |           0 |        0 |       0 |       0 |             1
+ 11 |     0 |     1 |           0 |        0 |       0 |       0 |             1
+ 12 |     1 |     0 |           0 |        1 |       0 |       0 |             0
+ 13 |     1 |     0 |           0 |        0 |       0 |       0 |             1
+ 14 |     0 |     1 |           0 |        1 |       0 |       0 |             0
+ 15 |     0 |     1 |           0 |        1 |       0 |       0 |             0
+ 16 |     1 |     0 |           0 |        0 |       0 |       0 |             1
+ 17 |     0 |     0 |           1 |        0 |       1 |       0 |             0
+ 18 |     0 |     1 |           0 |        1 |       0 |       0 |             0
+ 19 |     1 |     0 |           0 |        0 |       1 |       0 |             0
+ 20 |     0 |     0 |           0 |        0 |       0 |       1 |             0
+(20 rows)
+</pre>
+
+-# If you want to see both the raw categorical variable and its
+encoded form in the output_table, then include the categorical
+variable(s) in the index parameter.  (Remember that this will
+not work if you specify '*' for the parameter 'categorical_cols',
+because in this case 'row_id' columns will not be encoded at all.)
+<pre class="example">
+DROP TABLE IF EXISTS abalone_out, abalone_out_dictionary;
+SELECT madlib.encode_categorical_variables (
+        'abalone',                   -- Source table
+        'abalone_out',               -- Output table
+        'sex, rings',                -- Categorical columns
+        NULL,                        -- Categorical columns to exclude
+        'id, sex, rings'             -- Index columns
+        );
+SELECT * FROM abalone_out ORDER BY id;
+</pre>
+<pre class="result">
+ id | sex | rings | sex_F | sex_I | sex_M | rings_10 | rings_11 | rings_12 | rings_14 | rings_15 | rings_16 | rings_19 | rings_20 | rings_7 | rings_8 | rings_9
+----+-----+-------+-------+-------+-------+----------+----------+----------+----------+----------+----------+----------+----------+---------+---------+---------
+  1 | M   |    15 |     0 |     0 |     1 |        0 |        0 |        0 |        0 |        1 |        0 |        0 |        0 |       0 |       0 |       0
+  2 | M   |     7 |     0 |     0 |     1 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |       1 |       0 |       0
+  3 | F   |     9 |     1 |     0 |     0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |       0 |       0 |       1
+  4 | M   |    10 |     0 |     0 |     1 |        1 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |       0 |       0 |       0
+  5 | I   |     7 |     0 |     1 |     0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |       1 |       0 |       0
+  6 | I   |     8 |     0 |     1 |     0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |       0 |       1 |       0
+  7 | F   |    20 |     1 |     0 |     0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |        1 |       0 |       0 |       0
+  8 | F   |    16 |     1 |     0 |     0 |        0 |        0 |        0 |        0 |        0 |        1 |        0 |        0 |       0 |       0 |       0
+  9 | M   |     9 |     0 |     0 |     1 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |       0 |       0 |       1
+ 10 |     |    19 |     0 |     0 |     0 |        0 |        0 |        0 |        0 |        0 |        0 |        1 |        0 |       0 |       0 |       0
+ 11 | F   |    14 |     1 |     0 |     0 |        0 |        0 |        0 |        1 |        0 |        0 |        0 |        0 |       0 |       0 |       0
+ 12 | M   |    10 |     0 |     0 |     1 |        1 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |       0 |       0 |       0
+ 13 | M   |    11 |     0 |     0 |     1 |        0 |        1 |        0 |        0 |        0 |        0 |        0 |        0 |       0 |       0 |       0
+ 14 | F   |    10 |     1 |     0 |     0 |        1 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |       0 |       0 |       0
+ 15 | F   |    10 |     1 |     0 |     0 |        1 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |       0 |       0 |       0
+ 16 | M   |    12 |     0 |     0 |     1 |        0 |        0 |        1 |        0 |        0 |        0 |        0 |        0 |       0 |       0 |       0
+ 17 | I   |     7 |     0 |     1 |     0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |       1 |       0 |       0
+ 18 | F   |    10 |     1 |     0 |     0 |        1 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |       0 |       0 |       0
+ 19 | M   |     7 |     0 |     0 |     1 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |       1 |       0 |       0
+ 20 |     |     9 |     0 |     0 |     0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |        0 |       0 |       0 |       1
+(20 rows)
+</pre>
+
+-# For dummy encoding, let's make the 'I' value from the 'sex' variable as the reference.
+Here we use the 'value_to_drop' parameter:
+<pre class="example">
+DROP TABLE IF EXISTS abalone_out, abalone_out_dictionary;
+SELECT madlib.encode_categorical_variables (
+        'abalone',                   -- Source table
+        'abalone_out',               -- Output table
+        '*',                         -- Categorical columns
+        'rings',                     -- Categorical columns to exclude
+        'id',                        -- Index columns
+        NULL,                        -- Top value
+        'sex=I'                      -- Value to drop for dummy encoding
+        );
+SELECT * FROM abalone_out ORDER BY id;
+</pre>
+<pre class="result">
+  id | sex_F | sex_M
+----+-------+-------
+  1 |     0 |     1
+  2 |     0 |     1
+  3 |     1 |     0
+  4 |     0 |     1
+  5 |     0 |     0
+  6 |     0 |     0
+  7 |     1 |     0
+  8 |     1 |     0
+  9 |     0 |     1
+ 10 |     0 |     0
+ 11 |     1 |     0
+ 12 |     0 |     1
+ 13 |     0 |     1
+ 14 |     1 |     0
+ 15 |     1 |     0
+ 16 |     0 |     1
+ 17 |     0 |     0
+ 18 |     1 |     0
+ 19 |     0 |     1
+ 20 |     0 |     0
+(20 rows)
+</pre>
+
+-# Create an array output for the two categorical variables in the source table:
+<pre class="example">
+DROP TABLE IF EXISTS abalone_out, abalone_out_dictionary;
+SELECT madlib.encode_categorical_variables (
+        'abalone',                   -- Source table
+        'abalone_out',               -- Output table
+        '*',                         -- Categorical columns
+        NULL,                        -- Categorical columns to exclude
+        'id',                        -- Index columns
+        NULL,                        -- Top values
+        NULL,                        -- Value to drop for dummy encoding
+        NULL,                        -- Encode nulls
+        TRUE                         -- Array output
+        );
+SELECT * FROM abalone_out ORDER BY id;
+</pre>
+<pre class="result">
+ id |     __encoded_variables__
+----+-------------------------------
+  1 | {0,0,1,0,0,0,0,1,0,0,0,0,0,0}
+  2 | {0,0,1,0,0,0,0,0,0,0,0,1,0,0}
+  3 | {1,0,0,0,0,0,0,0,0,0,0,0,0,1}
+  4 | {0,0,1,1,0,0,0,0,0,0,0,0,0,0}
+  5 | {0,1,0,0,0,0,0,0,0,0,0,1,0,0}
+  6 | {0,1,0,0,0,0,0,0,0,0,0,0,1,0}
+  7 | {1,0,0,0,0,0,0,0,0,0,1,0,0,0}
+  8 | {1,0,0,0,0,0,0,0,1,0,0,0,0,0}
+  9 | {0,0,1,0,0,0,0,0,0,0,0,0,0,1}
+ 10 | {0,0,0,0,0,0,0,0,0,1,0,0,0,0}
+ 11 | {1,0,0,0,0,0,1,0,0,0,0,0,0,0}
+ 12 | {0,0,1,1,0,0,0,0,0,0,0,0,0,0}
+ 13 | {0,0,1,0,1,0,0,0,0,0,0,0,0,0}
+ 14 | {1,0,0,1,0,0,0,0,0,0,0,0,0,0}
+ 15 | {1,0,0,1,0,0,0,0,0,0,0,0,0,0}
+ 16 | {0,0,1,0,0,1,0,0,0,0,0,0,0,0}
+ 17 | {0,1,0,0,0,0,0,0,0,0,0,1,0,0}
+ 18 | {1,0,0,1,0,0,0,0,0,0,0,0,0,0}
+ 19 | {0,0,1,0,0,0,0,0,0,0,0,1,0,0}
+ 20 | {0,0,0,0,0,0,0,0,0,0,0,0,0,1}
+(20 rows)
+</pre>
+View the dictionary table that gives the index into the array:
+<pre class="example">
+SELECT * FROM abalone_out_dictionary;
+</pre>
+<pre class="result">
+  encoded_column_name  | index | variable | value
+-----------------------+-------+----------+-------
+ __encoded_variables__ |     1 | sex      | F
+ __encoded_variables__ |     2 | sex      | I
+ __encoded_variables__ |     3 | sex      | M
+ __encoded_variables__ |     4 | rings    | 10
+ __encoded_variables__ |     5 | rings    | 11
+ __encoded_variables__ |     6 | rings    | 12
+ __encoded_variables__ |     7 | rings    | 14
+ __encoded_variables__ |     8 | rings    | 15
+ __encoded_variables__ |     9 | rings    | 16
+ __encoded_variables__ |    10 | rings    | 19
+ __encoded_variables__ |    11 | rings    | 20
+ __encoded_variables__ |    12 | rings    | 7
+ __encoded_variables__ |    13 | rings    | 8
+ __encoded_variables__ |    14 | rings    | 9
+(14 rows)
+</pre>
+-# Create a dictionary output:
+<pre class="example">
+DROP TABLE IF EXISTS abalone_out, abalone_out_dictionary;
+SELECT madlib.encode_categorical_variables (
+        'abalone',                   -- Source table
+        'abalone_out',               -- Output table
+        '*',                         -- Categorical columns
+        NULL,                        -- Categorical columns to exclude
+        'id',                        -- Index columns
+        NULL,                        -- Top values
+        NULL,                        -- Value to drop for dummy encoding
+        NULL,                        -- Encode nulls
+        FALSE,                       -- Array output
+        TRUE                         -- Dictionary output
+        );
+SELECT * FROM abalone_out ORDER BY id;
+</pre>
+<pre class="result">
+  id | sex_1 | sex_2 | sex_3 | rings_1 | rings_2 | rings_3 | rings_4 | rings_5 | rings_6 | rings_7 | rings_8 | rings_9 | rings_10 | rings_11
+----+-------+-------+-------+---------+---------+---------+---------+---------+---------+---------+---------+---------+----------+----------
+  1 |     0 |     0 |     1 |       0 |       0 |       0 |       0 |       1 |       0 |       0 |       0 |       0 |        0 |        0
+  2 |     0 |     0 |     1 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |       1 |        0 |        0
+  3 |     1 |     0 |     0 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |        0 |        1
+  4 |     0 |     0 |     1 |       1 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |        0 |        0
+  5 |     0 |     1 |     0 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |       1 |        0 |        0
+  6 |     0 |     1 |     0 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |        1 |        0
+  7 |     1 |     0 |     0 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |       1 |       0 |        0 |        0
+  8 |     1 |     0 |     0 |       0 |       0 |       0 |       0 |       0 |       1 |       0 |       0 |       0 |        0 |        0
+  9 |     0 |     0 |     1 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |        0 |        1
+ 10 |     0 |     0 |     0 |       0 |       0 |       0 |       0 |       0 |       0 |       1 |       0 |       0 |        0 |        0
+ 11 |     1 |     0 |     0 |       0 |       0 |       0 |       1 |       0 |       0 |       0 |       0 |       0 |        0 |        0
+ 12 |     0 |     0 |     1 |       1 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |        0 |        0
+ 13 |     0 |     0 |     1 |       0 |       1 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |        0 |        0
+ 14 |     1 |     0 |     0 |       1 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |        0 |        0
+ 15 |     1 |     0 |     0 |       1 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |        0 |        0
+ 16 |     0 |     0 |     1 |       0 |       0 |       1 |       0 |       0 |       0 |       0 |       0 |       0 |        0 |        0
+ 17 |     0 |     1 |     0 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |       1 |        0 |        0
+ 18 |     1 |     0 |     0 |       1 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |        0 |        0
+ 19 |     0 |     0 |     1 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |       1 |        0 |        0
+ 20 |     0 |     0 |     0 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |        0 |        1
+(20 rows)
+</pre>
+View the dictionary table that defines the numerical columns in the output table:
+<pre class="example">
+SELECT * FROM abalone_out_dictionary ORDER BY encoded_column_name;
+</pre>
+<pre class="result">
+  encoded_column_name | index | variable | value
+---------------------+-------+----------+-------
+ "rings_1"           |     1 | rings    | 10
+ "rings_10"          |    10 | rings    | 8
+ "rings_11"          |    11 | rings    | 9
+ "rings_2"           |     2 | rings    | 11
+ "rings_3"           |     3 | rings    | 12
+ "rings_4"           |     4 | rings    | 14
+ "rings_5"           |     5 | rings    | 15
+ "rings_6"           |     6 | rings    | 16
+ "rings_7"           |     7 | rings    | 19
+ "rings_8"           |     8 | rings    | 20
+ "rings_9"           |     9 | rings    | 7
+ "sex_1"             |     1 | sex      | F
+ "sex_2"             |     2 | sex      | I
+ "sex_3"             |     3 | sex      | M
+(14 rows)
+</pre>
+
+-# We can chose from various distribution policies, for examply RANDOMLY:
+<pre class="example">
+DROP TABLE IF EXISTS abalone_out, abalone_out_dictionary;
+SELECT madlib.encode_categorical_variables (
+        'abalone',                   -- Source table
+        'abalone_out',               -- Output table
+        '*',                         -- Categorical columns
+        NULL,                        -- Categorical columns to exclude
+        'id',                        -- Index columns
+        NULL,                        -- Top values
+        NULL,                        -- Value to drop for dummy encoding
+        NULL,                        -- Encode nulls
+        NULL,                        -- Array output
+        NULL,                        -- Dictionary output
+        'RANDOMLY'                   -- Distribution policy
+        );
+</pre>
+
+-# If you have a reason to encode FLOAT variables, you can cast them
+in the following way within the function call:
+<pre class="example">
+DROP TABLE IF EXISTS abalone_out, abalone_out_dictionary;
+SELECT madlib.encode_categorical_variables (
+        'abalone',                   -- Source table
+        'abalone_out',               -- Output table
+        'height::TEXT'               -- Categorical columns
+        );
+</pre>
+
+@anchor literature
+@literature
+
+@anchor svm-lit-1
+[1] https://en.wikipedia.org/wiki/Categorical_variable
+
+[2] https://archive.ics.uci.edu/ml/datasets/Abalone
+
 */
-
 -------------------------------------------------------------------------
 
 /**

--- a/src/ports/postgres/modules/utilities/encode_categorical.sql_in
+++ b/src/ports/postgres/modules/utilities/encode_categorical.sql_in
@@ -76,7 +76,7 @@ encode_categorical_variables (
         row_id,                         -- Optional
         top,                            -- Optional
         value_to_drop,                  -- Optional
-        encode_null,                      -- Optional
+        encode_null,                    -- Optional
         array_output,                   -- Optional
         output_dictionary,              -- Optional
         distributed_by                  -- Optional
@@ -136,7 +136,7 @@ encode_categorical_variables (
     - Set to NULL for one-hot encoding (default)
     </dd>
 
-    <dt>keep_null (optional)</dt>
+    <dt>encode_null (optional)</dt>
     <dd>BOOLEAN. default: FALSE. Whether 'NULL' should be treated as one of the
     values of the categorical variable. If TRUE, then an indicator
     variable is created corresponding to the NULL value. If FALSE, then
@@ -300,7 +300,7 @@ select * from abalone_out;
  * @param row_id Columns from source table to index output table
  * @param top Parameter to include only top values of a categorical variable
  * @param value_to_drop Parameter to set reference column in dummy coding
- * @param keep_null Boolean to determine the behavior for rows with NULL value
+ * @param encode_null Boolean to determine the behavior for rows with NULL value
  * @param array_output Boolean to determine if output should be in an array or columns
  * @param output_dictionary Boolean to simplify column naming and with a separate
  *                              mapping table to actual values
@@ -322,7 +322,7 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.encode_categorical_variables(
     row_id                          VARCHAR,
     top                             VARCHAR,
     value_to_drop                   VARCHAR,
-    keep_null                       BOOLEAN,
+    encode_null                     BOOLEAN,
     array_output                    BOOLEAN,
     output_dictionary               BOOLEAN,
     distributed_by                  VARCHAR
@@ -341,7 +341,7 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.encode_categorical_variables(
     row_id                          VARCHAR,
     top                             VARCHAR,
     value_to_drop                   VARCHAR,
-    keep_null                       BOOLEAN,
+    encode_null                     BOOLEAN,
     array_output                    BOOLEAN,
     output_dictionary               BOOLEAN
 ) RETURNS VOID AS $$
@@ -360,7 +360,7 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.encode_categorical_variables(
     row_id                          VARCHAR,
     top                             VARCHAR,
     value_to_drop                   VARCHAR,
-    keep_null                       BOOLEAN,
+    encode_null                     BOOLEAN,
     array_output                    BOOLEAN
 ) RETURNS VOID AS $$
     PythonFunction(utilities, encode_categorical, encode_categorical_variables)
@@ -375,7 +375,7 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.encode_categorical_variables(
     row_id                          VARCHAR,
     top                             VARCHAR,
     value_to_drop                   VARCHAR,
-    keep_null                       BOOLEAN
+    encode_null                     BOOLEAN
 ) RETURNS VOID AS $$
     PythonFunction(utilities, encode_categorical, encode_categorical_variables)
 $$ LANGUAGE plpythonu

--- a/src/ports/postgres/modules/utilities/test/encode_categorical.sql_in
+++ b/src/ports/postgres/modules/utilities/test/encode_categorical.sql_in
@@ -1,0 +1,102 @@
+/* ----------------------------------------------------------------------- *//**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *//* ----------------------------------------------------------------------- */
+
+---------------------------------------------------------------------------
+-- Build training dataset:
+---------------------------------------------------------------------------
+DROP TABLE IF EXISTS abalone;
+CREATE TABLE abalone (
+    id serial,
+    sex character varying,
+    length double precision,
+    diameter double precision,
+    height double precision,
+    "Class" integer
+);
+COPY abalone (sex, length, diameter, height, "Class") FROM stdin WITH DELIMITER '|' NULL as '@';
+M|0.455|0.365|0.095|0
+F|0.53|0.42|0.135|0
+M|0.35|0.265|0.09|0
+F|0.53|0.415|0.15|0
+M|0.44|0.365|0.125|0
+F|0.545|0.425|0.125|0
+I|0.33|0.255|0.08|0
+F|0.55|0.44|0.15|0
+I|0.425|0.30|0.095|0
+F|0.525|0.38|0.140|0
+M|0.475|0.37|0.125|0
+F|0.535|0.405|0.145|0
+M|0.43|0.358|0.11|1
+F|0.47|0.355|0.100|1
+M|0.49|0.38|0.135|1
+F|0.44|0.340|0.100|1
+M|0.5|0.400|0.13|1
+F|0.565|0.44|0.155|2
+I|0.355|0.280|0.085|2
+F|0.550|0.415|0.135|2
+@|0.475|0.37|0.125|2
+\.
+
+SELECT * FROM abalone;
+
+-- default test
+select madlib.encode_categorical_variables('abalone', 'abalone_out1', 'sex');
+select * from abalone_out1;
+
+-- ignoring numeric columns
+select madlib.encode_categorical_variables('abalone', 'abalone_out2', 'sex, length');
+select * from abalone_out2;
+
+-- row_id showing multiple columns,
+-- top and value_to_drop able to work together with unquoted column names
+select madlib.encode_categorical_variables('abalone', 'abalone_out3',
+                                           'sex, "Class"', 'class',
+                                           'id, sex, "Class"', '2', 'sex=M, Class=1',
+                                           true, false, false
+                                           );
+select * from abalone_out3;
+
+-- * working, exclude working, global value_to_drop working
+select madlib.encode_categorical_variables('abalone', 'abalone_out4',
+                                           '*', '"Class"',
+                                           'id', '2', 'M',
+                                           true, false, false
+                                           );
+select * from abalone_out4;
+
+-- array output working with dictionary output,
+-- top with percent input, global value_to_drop
+select madlib.encode_categorical_variables('abalone', 'abalone_out5',
+                                           'sex, "Class"', '',
+                                           'id', '0.5', 'M',
+                                           true, true, false
+                                           );
+select * from abalone_out5;
+select * from abalone_out5_dictionary order by index;
+
+-- dictionary working, top with more than possible values working
+select madlib.encode_categorical_variables('abalone', 'abalone_out6',
+                                           'sex, "Class"', '',
+                                           'id', '3', 'class=1',
+                                           true, false, true
+                                           );
+select * from abalone_out6;
+select * from abalone_out6_dictionary order by variable, index;

--- a/src/ports/postgres/modules/utilities/utilities.py_in
+++ b/src/ports/postgres/modules/utilities/utilities.py_in
@@ -1,4 +1,3 @@
-m4_changequote(`<!', `!>')
 
 import re
 import time
@@ -6,6 +5,8 @@ import random
 from distutils.util import strtobool
 
 if __name__ != "__main__":
+    from validate_args import _get_table_schema_names
+    from validate_args import get_first_schema
     import plpy
 
 
@@ -17,7 +18,7 @@ def _assert(condition, msg):
     """
     if not condition:
         plpy.error(msg)
-# ========================================================================
+# ------------------------------------------------------------------------------
 
 
 def warn(condition, msg):
@@ -28,6 +29,40 @@ def warn(condition, msg):
     """
     if not condition:
         plpy.warning(msg)
+# ------------------------------------------------------------------------------
+
+
+m4_changequote(`<!', `!>')
+def get_distribution_policy(source_table):
+    """ Return a list of columns that define the distribution policy of source_table
+    Args:
+        @param source_table
+
+    Returns:
+        List of str.
+    """
+    _, table_name = _get_table_schema_names(source_table)
+    schema_name = get_first_schema(source_table)
+    dist_attr = plpy.execute("""
+    SELECT array_agg(pga.attname) as dist_attr
+    FROM (
+        SELECT gdp.localoid,
+                 CASE
+                     WHEN ( ARRAY_UPPER(gdp.attrnums, 1) > 0 ) THEN
+                        UNNEST(gdp.attrnums)
+                     ELSE NULL
+                 END AS attnum
+            FROM gp_distribution_policy gdp
+        ) AS distkey
+        INNER JOIN pg_class AS pgc
+        ON distkey.localoid = pgc.oid AND pgc.relname = '{table_name}'
+        INNER JOIN pg_namespace pgn
+        ON pgc.relnamespace = pgn.oid AND pgn.nspname = '{schema_name}'
+        LEFT OUTER JOIN pg_attribute pga
+        ON distkey.attnum = pga.attnum AND distkey.localoid = pga.attrelid
+    """.format(table_name=table_name, schema_name=schema_name))[0]["dist_attr"]
+    return dist_attr
+# ------------------------------------------------------------------------------
 
 
 def get_seg_number():
@@ -41,7 +76,7 @@ def get_seg_number():
         WHERE role = 'p'
         """)[0]['count']
     !>)
-# ------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
 
 def is_orca():
@@ -51,7 +86,12 @@ def is_orca():
     !>, <!
     return False
     !>)
-# -------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
+
+
+def is_platform_pg():
+    return m4_ifdef(<!__POSTGRESQL__!>, <!True!>, <!False!>)
+# ------------------------------------------------------------------------------
 
 
 def num_features(source_table, independent_varname):
@@ -59,13 +99,13 @@ def num_features(source_table, independent_varname):
                         "FROM {1} LIMIT 1"
                         .format(independent_varname,
                                 source_table))[0]['dim']
-# ------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
 
 def num_samples(source_table):
     return plpy.execute("SELECT count(*) AS n FROM {0}"
                         .format(source_table))[0]['n']
-# ------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
 
 def unique_string(desp='', **kwargs):
@@ -78,7 +118,7 @@ def unique_string(desp='', **kwargs):
     r3 = int(time.time()) % random.randint(1, 100000000)
     u_string = "__madlib_temp_" + desp + str(r1) + "_" + str(r2) + "_" + str(r3) + "__"
     return u_string
-# -------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
 
 def add_postfix(quoted_string, postfix):
@@ -407,7 +447,7 @@ def _string_to_sql_array(schema_madlib, s, **kwargs):
     for i in range(len(elm)):
         elm[i] = elm[i].strip("\"")
     return array_to_string(elm)
-# ========================================================================
+# ------------------------------------------------------------------------
 
 
 def current_user():
@@ -425,7 +465,7 @@ def madlib_version(schema_madlib):
 # ------------------------------------------------------------------------
 
 
-def preprocess_keyvalue_params(input_params, split_char='='):
+def preprocess_keyvalue_params(input_params, split_char='=', quote_char='"'):
     """
     Parse the input_params string and split it using the split_char
 
@@ -438,8 +478,8 @@ def preprocess_keyvalue_params(input_params, split_char='='):
 
 
     """
-    re_str = (r"([-\w]+\s*" +     # key is any alphanumeric character
-                                  # (including -) string
+    re_str = (r"([-:\w]+\s*" +    # key is any alphanumeric character
+                                  # (including - and :) string
               split_char +        # key and value are separated by split_char
               r"""
                 \s*([\(\{\[]      # value can be string or array
@@ -461,9 +501,10 @@ def preprocess_keyvalue_params(input_params, split_char='='):
 
 
 def extract_keyvalue_params(input_params,
-                            input_param_types,
+                            input_param_types=None,
                             default_values=None,
-                            split_char='='):
+                            split_char='=',
+                            allow_duplicates=True):
     """ Extract key value pairs from input parameters or set the default values
 
     Args:
@@ -480,6 +521,10 @@ def extract_keyvalue_params(input_params,
         @param default_values: dict, Default values for each allowed parameter.
         @param split_char: str, The character used to split key and value.
                             Default set to '='
+        @param allow_duplicates: bool, Allow repeat of a 'key' in input_params,
+                                where the last occurence will be reflected
+                                in the output. If False, then a ValueError is
+                                raised.
 
     Returns:
         Dict. Dictionary of input parameter values with key as parameter name
@@ -505,28 +550,38 @@ def extract_keyvalue_params(input_params,
         param_value = items[1].strip()
         if not param_name or param_name in ('none', 'null'):
             plpy.error("Invalid input param name: {0} ".format(str(param_name)))
-        try:
-            param_type = input_param_types[param_name]
-        except KeyError:
-            raise KeyError("Invalid input: {0} is not a valid parameter".
-                           format(param_name))
-        try:
-            if param_type in (int, str, float):
-                parameter_dict[param_name] = param_type(param_value)
-            elif param_type == list:
-                parameter_dict[param_name] = split_quoted_delimited_str(
-                    param_value.strip('[](){} '))
-            elif param_type == bool:
-                #  True values are y, yes, t, true, on and 1;
-                #  False values are n, no, f, false, off and 0.
-                #  Raises ValueError if anything else.
-                parameter_dict[param_name] = bool(strtobool(param_value))
-            else:
-                raise TypeError("Invalid input: {0} has unsupported type".
-                                format(param_name))
-        except ValueError:
-            raise ValueError("Invalid input: {0} must be {1}".
-                             format(param_name, str(param_type)))
+
+        if not allow_duplicates and param_name in parameter_dict:
+            raise ValueError("Invalid input: {0} duplicated in the param list".
+                             format(param_name))
+
+        if input_param_types:
+            try:
+                param_type = input_param_types[param_name]
+            except KeyError:
+                raise ValueError("Invalid input: {0} is not a valid parameter".
+                                 format(param_name))
+            try:
+                if param_type in (int, str, float):
+                    parameter_dict[param_name] = param_type(param_value)
+                elif param_type == list:
+                    parameter_dict[param_name] = split_quoted_delimited_str(
+                        param_value.strip('[](){} '))
+                elif param_type == bool:
+                    #  True values are y, yes, t, true, on and 1;
+                    #  False values are n, no, f, false, off and 0.
+                    #  Raises ValueError if anything else.
+                    parameter_dict[param_name] = bool(strtobool(param_value))
+                else:
+                    raise TypeError("Invalid input: {0} has unsupported type".
+                                    format(param_name))
+            except ValueError:
+                raise ValueError("Invalid input: {0} must be {1}".
+                                 format(param_name, str(param_type)))
+        else:
+            # if input parameter types not provided then just return all as string
+            parameter_dict[param_name] = str(param_value)
+
     return parameter_dict
 # -------------------------------------------------------------------------
 
@@ -590,17 +645,17 @@ class UtilitiesTestCase(unittest.TestCase):
         Python Exceptions to successfully run the test cases
     """
     def setUp(self):
-        self.optimizer_params1 = 'max_iter=10, optimizer="irls", precision=1e-4'
+        self.optimizer_params1 = 'max_iter=10, optimizer::text="irls", precision=1e-4'
         self.optimizer_params2 = 'max_iter=2.01, optimizer=newton-irls, precision=1e-5'
         self.optimizer_params3 = 'max_iter=10, 10, optimizer=, lambda={1,"2,2",3,4}'
         self.optimizer_params4 = ('max_iter=10, optimizer="irls",'
                                   'precision=0.02.01, lambda={1,2,3,4}')
-        self.optimizer_types = {'max_iter': int, 'optimizer': str,
+        self.optimizer_types = {'max_iter': int, 'optimizer': str, 'optimizer::text': str,
                                 'lambda': list, 'precision': float}
 
     def test_preprocess_optimizer(self):
         self.assertEqual(preprocess_keyvalue_params(self.optimizer_params1),
-                         ['max_iter=10', 'optimizer="irls"', 'precision=1e-4'])
+                         ['max_iter=10', 'optimizer::text="irls"', 'precision=1e-4'])
         self.assertEqual(preprocess_keyvalue_params(self.optimizer_params2),
                          ['max_iter=2.01', 'optimizer=newton-irls', 'precision=1e-5'])
         self.assertEqual(preprocess_keyvalue_params(self.optimizer_params3),
@@ -609,17 +664,22 @@ class UtilitiesTestCase(unittest.TestCase):
                          ['max_iter=10', 'optimizer="irls"', 'precision=0.02', 'lambda={1,2,3,4}'])
 
     def test_extract_optimizers(self):
-        self.assertEqual({'max_iter': 10, 'optimizer': '"irls"', 'precision': 0.0001},
+        self.assertEqual({'max_iter': 10, 'optimizer::text': '"irls"', 'precision': 0.0001},
                          extract_keyvalue_params(self.optimizer_params1, self.optimizer_types))
         self.assertEqual({'max_iter': 10, 'lambda': ['1', '"2,2"', '3', '4']},
                          extract_keyvalue_params(self.optimizer_params3, self.optimizer_types))
         self.assertEqual({'max_iter': 10, 'optimizer': '"irls"', 'precision': 0.02,
                           'lambda': ['1', '2', '3', '4']},
                          extract_keyvalue_params(self.optimizer_params4, self.optimizer_types))
+        self.assertEqual({'max_iter': '10', 'optimizer': '"irls"', 'precision': '0.02',
+                          'lambda': '{1,2,3,4}'},
+                         extract_keyvalue_params(self.optimizer_params4))
         self.assertRaises(ValueError,
                           extract_keyvalue_params, self.optimizer_params2, self.optimizer_types)
 
     def test_split_delimited_string(self):
+        self.assertEqual(['max_iter=10', 'optimizer::text="irls"', 'precision=1e-4'],
+                         split_quoted_delimited_str(self.optimizer_params1, quote='"'))
         self.assertEqual(['a', 'b', 'c'], split_quoted_delimited_str('a,    b, c', quote='|'))
         self.assertEqual(['a', '|b, c|'], split_quoted_delimited_str('a,    |b, c|', quote='|'))
         self.assertEqual(['a', '"b, c"'], split_quoted_delimited_str('a, "b, c"'))

--- a/src/ports/postgres/modules/utilities/utilities.py_in
+++ b/src/ports/postgres/modules/utilities/utilities.py_in
@@ -470,7 +470,7 @@ def madlib_version(schema_madlib):
 # ------------------------------------------------------------------------
 
 
-def preprocess_keyvalue_params(input_params, split_char='=', quote_char='"'):
+def preprocess_keyvalue_params(input_params, split_char='='):
     """
     Parse the input_params string and split it using the split_char
 
@@ -480,12 +480,12 @@ def preprocess_keyvalue_params(input_params, split_char='=', quote_char='"'):
             value is either and
     @param split_char: str, character that splits the key and value elements.
                         Default set to '='
-
-
     """
     re_str = (r"([-:\w]+\s*" +    # key is any alphanumeric character
                                   # (including - and :) string
+
               split_char +        # key and value are separated by split_char
+
               r"""
                 \s*([\(\{\[]      # value can be string or array
                 [^\[\]\(\)\{\}]*  #  if value is array then accept anything inside
@@ -493,10 +493,11 @@ def preprocess_keyvalue_params(input_params, split_char='=', quote_char='"'):
 
                    |              # either array (above) or string (below)
 
-                (?P<quote>\"?)[\w\s\-\%]*\.?[\w\s\-\%]+(?P=quote)
+                (?P<quote>\"?)[\w\s\-\%.]+(?P=quote)
                                  #  if value is string, it can be alphanumeric
                                  #    character string with a decimal dot,
-                                 #    optionally quoted by double quotes
+                                 #    hyphen, or percent
+                                 #    optionally quoted by `quote_char`
                   )
                )"""
               )
@@ -661,7 +662,7 @@ class UtilitiesTestCase(unittest.TestCase):
         self.optimizer_params4 = ('max_iter=10, optimizer="irls",'
                                   'precision=0.02.01, lambda={1,2,3,4}')
         self.optimizer_params5 = ('max_iter=10, optimizer="irls",'
-                                  'precision=0.02.01, PRECISION=0.02.01, lambda={1,2,3,4}')
+                                  'precision=0.02, PRECISION=2., lambda={1,2,3,4}')
         self.optimizer_types = {'max_iter': int, 'optimizer': str, 'optimizer::text': str,
                                 'lambda': list, 'precision': float}
 
@@ -673,21 +674,18 @@ class UtilitiesTestCase(unittest.TestCase):
         self.assertEqual(preprocess_keyvalue_params(self.optimizer_params3),
                          ['max_iter=10', 'lambda={1,"2,2",3,4}'])
         self.assertEqual(preprocess_keyvalue_params(self.optimizer_params4),
-                         ['max_iter=10', 'optimizer="irls"', 'precision=0.02', 'lambda={1,2,3,4}'])
+                         ['max_iter=10', 'optimizer="irls"', 'precision=0.02.01', 'lambda={1,2,3,4}'])
 
     def test_extract_optimizers(self):
         self.assertEqual({'max_iter': 10, 'optimizer::text': '"irls"', 'precision': 0.0001},
                          extract_keyvalue_params(self.optimizer_params1, self.optimizer_types))
         self.assertEqual({'max_iter': 10, 'lambda': ['1', '"2,2"', '3', '4']},
                          extract_keyvalue_params(self.optimizer_params3, self.optimizer_types))
-        self.assertEqual({'max_iter': 10, 'optimizer': '"irls"', 'precision': 0.02,
-                          'lambda': ['1', '2', '3', '4']},
-                         extract_keyvalue_params(self.optimizer_params4, self.optimizer_types))
-        self.assertEqual({'max_iter': '10', 'optimizer': '"irls"', 'precision': '0.02',
+        self.assertEqual({'max_iter': '10', 'optimizer': '"irls"', 'precision': '0.02.01',
                           'lambda': '{1,2,3,4}'},
                          extract_keyvalue_params(self.optimizer_params4))
         self.assertEqual({'max_iter': '10', 'optimizer': '"irls"',
-                          'PRECISION': '0.02', 'precision': '0.02',
+                          'PRECISION': '2.', 'precision': '0.02',
                           'lambda': '{1,2,3,4}'},
                          extract_keyvalue_params(self.optimizer_params5,
                                                  allow_duplicates=False,
@@ -697,6 +695,8 @@ class UtilitiesTestCase(unittest.TestCase):
                           extract_keyvalue_params, self.optimizer_params2, self.optimizer_types)
         self.assertRaises(ValueError,
                           extract_keyvalue_params, self.optimizer_params5, allow_duplicates=False)
+        self.assertRaises(ValueError,
+                          extract_keyvalue_params, self.optimizer_params4, self.optimizer_types)
 
     def test_split_delimited_string(self):
         self.assertEqual(['max_iter=10', 'optimizer::text="irls"', 'precision=1e-4'],

--- a/src/ports/postgres/modules/utilities/utilities.py_in
+++ b/src/ports/postgres/modules/utilities/utilities.py_in
@@ -10,6 +10,38 @@ if __name__ != "__main__":
     import plpy
 
 
+m4_changequote(`<!', `!>')
+
+
+def get_seg_number():
+    """ Find out how many primary segments exist in the distribution
+        Might be useful for partitioning data.
+    """
+    m4_ifdef(<!__POSTGRESQL__!>, <!return 1!>, <!
+    return plpy.execute(
+        """
+        SELECT count(*) from gp_segment_configuration
+        WHERE role = 'p'
+        """)[0]['count']
+    !>)
+# ------------------------------------------------------------------------------
+
+
+def is_orca():
+    m4_ifdef(<!__HAS_FUNCTION_PROPERTIES__!>, <!
+    optimizer = plpy.execute("show optimizer")[0]["optimizer"]
+    return True if optimizer == 'on' else False
+    !>, <!
+    return False
+    !>)
+# ------------------------------------------------------------------------------
+
+
+def is_platform_pg():
+    return m4_ifdef(<!__POSTGRESQL__!>, <!True!>, <!False!>)
+# ------------------------------------------------------------------------------
+
+
 def _assert(condition, msg):
     """
     @brief if the given condition is false, then raise an error with the message
@@ -32,7 +64,6 @@ def warn(condition, msg):
 # ------------------------------------------------------------------------------
 
 
-m4_changequote(`<!', `!>')
 def get_distribution_policy(source_table):
     """ Return a list of columns that define the distribution policy of source_table
     Args:
@@ -62,35 +93,6 @@ def get_distribution_policy(source_table):
         ON distkey.attnum = pga.attnum AND distkey.localoid = pga.attrelid
     """.format(table_name=table_name, schema_name=schema_name))[0]["dist_attr"]
     return dist_attr
-# ------------------------------------------------------------------------------
-
-
-def get_seg_number():
-    """ Find out how many primary segments exist in the distribution
-        Might be useful for partitioning data.
-    """
-    m4_ifdef(<!__POSTGRESQL__!>, <!return 1!>, <!
-    return plpy.execute(
-        """
-        SELECT count(*) from gp_segment_configuration
-        WHERE role = 'p'
-        """)[0]['count']
-    !>)
-# ------------------------------------------------------------------------------
-
-
-def is_orca():
-    m4_ifdef(<!__HAS_FUNCTION_PROPERTIES__!>, <!
-    optimizer = plpy.execute("show optimizer")[0]["optimizer"]
-    return True if optimizer == 'on' else False
-    !>, <!
-    return False
-    !>)
-# ------------------------------------------------------------------------------
-
-
-def is_platform_pg():
-    return m4_ifdef(<!__POSTGRESQL__!>, <!True!>, <!False!>)
 # ------------------------------------------------------------------------------
 
 
@@ -228,12 +230,15 @@ def _array_to_string(origin):
     return "{" + ",".join(map(str, origin)) + "}"
 # ------------------------------------------------------------------------
 
+
 def _cast_if_null(input, alias=''):
     if input:
         return str(input)
     else:
         null_str = "NULL::text"
         return null_str + " as " + alias if alias else null_str
+# ------------------------------------------------------------------------
+
 
 def set_client_min_messages(new_level):
     """
@@ -488,7 +493,7 @@ def preprocess_keyvalue_params(input_params, split_char='=', quote_char='"'):
 
                    |              # either array (above) or string (below)
 
-                (?P<quote>\"?)[\w\s\-\%]+\.?[\w\s\-\%]*(?P=quote)
+                (?P<quote>\"?)[\w\s\-\%]*\.?[\w\s\-\%]+(?P=quote)
                                  #  if value is string, it can be alphanumeric
                                  #    character string with a decimal dot,
                                  #    optionally quoted by double quotes
@@ -504,7 +509,8 @@ def extract_keyvalue_params(input_params,
                             input_param_types=None,
                             default_values=None,
                             split_char='=',
-                            allow_duplicates=True):
+                            allow_duplicates=True,
+                            lower_case_names=True):
     """ Extract key value pairs from input parameters or set the default values
 
     Args:
@@ -525,6 +531,7 @@ def extract_keyvalue_params(input_params,
                                 where the last occurence will be reflected
                                 in the output. If False, then a ValueError is
                                 raised.
+        @param lower_case_names: bool, Convert parameter names to lower case.
 
     Returns:
         Dict. Dictionary of input parameter values with key as parameter name
@@ -546,10 +553,13 @@ def extract_keyvalue_params(input_params,
         if (len(items) != 2):
             raise KeyError("Input parameter list has incorrect format")
 
-        param_name = items[0].strip(" \"").lower()
-        param_value = items[1].strip()
+        param_name = items[0].strip(" \"")
         if not param_name or param_name in ('none', 'null'):
             plpy.error("Invalid input param name: {0} ".format(str(param_name)))
+
+        if lower_case_names:
+            param_name = param_name.lower()
+        param_value = items[1].strip()
 
         if not allow_duplicates and param_name in parameter_dict:
             raise ValueError("Invalid input: {0} duplicated in the param list".
@@ -646,10 +656,12 @@ class UtilitiesTestCase(unittest.TestCase):
     """
     def setUp(self):
         self.optimizer_params1 = 'max_iter=10, optimizer::text="irls", precision=1e-4'
-        self.optimizer_params2 = 'max_iter=2.01, optimizer=newton-irls, precision=1e-5'
+        self.optimizer_params2 = 'max_iter=.01, optimizer=newton-irls, precision=1e-5'
         self.optimizer_params3 = 'max_iter=10, 10, optimizer=, lambda={1,"2,2",3,4}'
         self.optimizer_params4 = ('max_iter=10, optimizer="irls",'
                                   'precision=0.02.01, lambda={1,2,3,4}')
+        self.optimizer_params5 = ('max_iter=10, optimizer="irls",'
+                                  'precision=0.02.01, PRECISION=0.02.01, lambda={1,2,3,4}')
         self.optimizer_types = {'max_iter': int, 'optimizer': str, 'optimizer::text': str,
                                 'lambda': list, 'precision': float}
 
@@ -657,7 +669,7 @@ class UtilitiesTestCase(unittest.TestCase):
         self.assertEqual(preprocess_keyvalue_params(self.optimizer_params1),
                          ['max_iter=10', 'optimizer::text="irls"', 'precision=1e-4'])
         self.assertEqual(preprocess_keyvalue_params(self.optimizer_params2),
-                         ['max_iter=2.01', 'optimizer=newton-irls', 'precision=1e-5'])
+                         ['max_iter=.01', 'optimizer=newton-irls', 'precision=1e-5'])
         self.assertEqual(preprocess_keyvalue_params(self.optimizer_params3),
                          ['max_iter=10', 'lambda={1,"2,2",3,4}'])
         self.assertEqual(preprocess_keyvalue_params(self.optimizer_params4),
@@ -674,8 +686,17 @@ class UtilitiesTestCase(unittest.TestCase):
         self.assertEqual({'max_iter': '10', 'optimizer': '"irls"', 'precision': '0.02',
                           'lambda': '{1,2,3,4}'},
                          extract_keyvalue_params(self.optimizer_params4))
+        self.assertEqual({'max_iter': '10', 'optimizer': '"irls"',
+                          'PRECISION': '0.02', 'precision': '0.02',
+                          'lambda': '{1,2,3,4}'},
+                         extract_keyvalue_params(self.optimizer_params5,
+                                                 allow_duplicates=False,
+                                                 lower_case_names=False
+                                                 ))
         self.assertRaises(ValueError,
                           extract_keyvalue_params, self.optimizer_params2, self.optimizer_types)
+        self.assertRaises(ValueError,
+                          extract_keyvalue_params, self.optimizer_params5, allow_duplicates=False)
 
     def test_split_delimited_string(self):
         self.assertEqual(['max_iter=10', 'optimizer::text="irls"', 'precision=1e-4'],

--- a/src/ports/postgres/modules/utilities/validate_args.py_in
+++ b/src/ports/postgres/modules/utilities/validate_args.py_in
@@ -2,11 +2,6 @@
 import plpy
 import re
 import string
-from utilities import __mad_version
-
-
-version_wrapper = __mad_version()
-_string_to_array = version_wrapper.select_vecfunc()
 
 # Postgresql naming restrictions
 """
@@ -117,8 +112,8 @@ def _get_table_schema_names(tbl, only_first_schema=False):
             # restricted to the first schema in search path
             all_schemas = [plpy.execute("SELECT current_schema() AS cs")[0]["cs"]]
         else:
-            all_schemas = _string_to_array(plpy.execute(
-                "SELECT current_schemas(True) ""AS cs")[0]["cs"])
+            all_schemas = plpy.execute(
+                "SELECT current_schemas(True) ""AS cs")[0]["cs"]
         schema_str = "('{0}')".format("','".join(unquote_ident(s)
                                                  for s in all_schemas))
         table = unquote_ident(names[0])
@@ -241,20 +236,18 @@ def get_first_schema(table_name):
         return unquote_ident(names[0])
 
     # create a list of schema names in search path
-    # _string_to_array is used for GPDB versions less than 4.2 where an array
-    # is returned to Python as a string
-    current_schemas = _string_to_array(plpy.execute(
-        "SELECT current_schemas(True) AS cs")[0]["cs"])
+    current_schemas = plpy.execute(
+        "SELECT current_schemas(True) AS cs")[0]["cs"]
 
     if not current_schemas:
         return None
 
     # get all schemas that contain a table with this name
-    schemas_w_table = _string_to_array(plpy.execute(
+    schemas_w_table = plpy.execute(
         """SELECT array_agg(table_schema::text) AS schemas
            FROM information_schema.tables
            WHERE table_name='{table_name}'""".
-        format(table_name=table_name))[0]["schemas"])
+        format(table_name=table_name))[0]["schemas"]
 
     if not schemas_w_table:
         return None
@@ -313,7 +306,9 @@ def get_cols_and_types(tbl):
         @param tbl: string, Name of the table to search in
 
     Returns:
-        Dictionary. Key is the column name and the Value is the data type
+        List. Contains list of pair (col, type). The output is a list instead
+        of a dictionary since the columns are ordered in 'tbl' and this result
+        maintains that order.
 
     The data type returned will be the type name if it is a built-in type, or
     'ARRAY' if it is some array. For any other case it will be 'USER-DEFINED'.
@@ -343,15 +338,14 @@ def get_cols_and_types(tbl):
                     AND table_schema = '{schema}'
                 """.format(table=table, schema=schema)
     result = plpy.execute(sql_string)[0]
-    col_names = _string_to_array(result['cols'])
-    col_types = _string_to_array(result['types'])
+    col_names = result['cols']
+    col_types = result['types']
     return list(zip(col_names, col_types))
 # -------------------------------------------------------------------------
 
 
 def get_expr_type(expr, tbl):
-    """ Temporary function to obtain the type of an expression by importing
-    the expression data into python.
+    """ Temporary function to obtain the type of an expression
 
     Args:
         @param expr
@@ -519,9 +513,9 @@ def array_col_has_no_null(tbl, col):
                        FROM {tbl}
                        """.format(col=col, tbl=tbl))[0]["dim"]
     for i in range(1, dim + 1):
-        l = plpy.execute("SELECT count({col}[{i}]) FROM {tbl}".
-                         format(col=col, tbl=tbl, i=i))[0]["count"]
-        if row_len != l:
+        n_non_nulls = plpy.execute("SELECT count({col}[{i}]) FROM {tbl}".
+                                   format(col=col, tbl=tbl, i=i))[0]["count"]
+        if row_len != n_non_nulls:
             return False
     return True
 # -------------------------------------------------------------------------
@@ -532,7 +526,7 @@ def is_var_valid(tbl, var, order_by=None):
     Test whether the variable(s) is valid by actually selecting it from
     the table
     """
-    if var is None or var.lower().strip() == '':
+    if var is None or var.strip() == '':
         return False
     try:
         order_by_str = "" if not order_by else "ORDER BY " + order_by


### PR DESCRIPTION
JIRA: MADLIB-1038

Major overhaul of the dummy/one-hot encoding of categorical variables
with new name and updated arguments. Older function has been
deprecated with a warning to use the new function.