### PR TITLE
GPDB5 cherrypicked AggCheckCallContext, we have to exclude it for GPD…

### DIFF
--- a/src/ports/greenplum/5.0/CMakeLists.txt
+++ b/src/ports/greenplum/5.0/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_current_greenplum_version()

--- a/src/ports/greenplum/cmake/FindGreenplum_5_0.cmake
+++ b/src/ports/greenplum/cmake/FindGreenplum_5_0.cmake
@@ -1,0 +1,2 @@
+set(_FIND_PACKAGE_FILE "${CMAKE_CURRENT_LIST_FILE}")
+include("${CMAKE_CURRENT_LIST_DIR}/FindGreenplum.cmake")

--- a/src/ports/greenplum/dbconnector/Compatibility.hpp
+++ b/src/ports/greenplum/dbconnector/Compatibility.hpp
@@ -27,6 +27,7 @@ namespace {
 	SearchSysCache(cacheId, key1, 0, 0, 0)
 #endif
 
+#if (GP_VERSION_NUM < 40399)
 /*
  * In commit 2d4db3675fa7a2f4831b755bc98242421901042f,
  * by Tom Lane <tgl@sss.pgh.pa.us> Wed, 6 Jun 2007 23:00:50 +0000,
@@ -75,7 +76,7 @@ AggCheckCallContext(FunctionCallInfo fcinfo, MemoryContext *aggcontext) {
 		*aggcontext = NULL;
 	return 0;
 }
-
+#endif // GP_VERSION_NUM < 40399
 } // namespace
 
 inline ArrayType* madlib_construct_array

--- a/src/ports/postgres/dbconnector/Compatibility.hpp
+++ b/src/ports/postgres/dbconnector/Compatibility.hpp
@@ -54,7 +54,7 @@ namespace {
     #define type_is_array(x) is_array_type(x)
 #endif
 
-#if (PG_VERSION_NUM < 90000 || (defined(GP_VERSION_NUMBER) && GP_VERSION_NUMBER < 40399)
+#if (PG_VERSION_NUM < 90000)  
 
 /**
  * The following has existed in PostgresSQL since commit ID

--- a/src/ports/postgres/dbconnector/Compatibility.hpp
+++ b/src/ports/postgres/dbconnector/Compatibility.hpp
@@ -54,7 +54,7 @@ namespace {
     #define type_is_array(x) is_array_type(x)
 #endif
 
-#if PG_VERSION_NUM < 90000
+#if (PG_VERSION_NUM < 90000 || (defined(GP_VERSION_NUMBER) && GP_VERSION_NUMBER < 40399)
 
 /**
  * The following has existed in PostgresSQL since commit ID

--- a/src/ports/postgres/dbconnector/Compatibility.hpp
+++ b/src/ports/postgres/dbconnector/Compatibility.hpp
@@ -54,7 +54,7 @@ namespace {
     #define type_is_array(x) is_array_type(x)
 #endif
 
-#if (PG_VERSION_NUM < 90000)  
+#if PG_VERSION_NUM < 90000 
 
 /**
  * The following has existed in PostgresSQL since commit ID


### PR DESCRIPTION
…B5 builds