### PR TITLE
Fix headerguard for MallocAllocator

### DIFF
--- a/src/utils/MallocAllocator.hpp
+++ b/src/utils/MallocAllocator.hpp
@@ -5,7 +5,7 @@
  *//* ----------------------------------------------------------------------- */
 
 #ifndef MADLIB_MALLOC_ALLOCATOR_HPP
-#define MADLIB_NALLOC_ALLOCATOR_HPP
+#define MADLIB_MALLOC_ALLOCATOR_HPP
 
 namespace madlib {
 


### PR DESCRIPTION
The headerguard for MallocAllocator is defining a different macro than what it's testing for (seems to be an off-by-one on the keyboard). Fix the defined macro to match the check and filename.