### PR TITLE
Task: Skip install-check for pmml

### DIFF
--- a/src/madpack/madpack.py
+++ b/src/madpack/madpack.py
@@ -1424,6 +1424,11 @@ def main(argv):
             # Skip if doesn't meet specified modules
             if modset is not None and len(modset) > 0 and module not in modset:
                 continue
+            # JIRA: MADLIB-1078 fix
+            # Skip pmml during install-check (when run without the -t option).
+            # We can still run install-check on pmml with '-t' option.
+            if not modset and module in ['pmml']:
+                continue
             _info("> - %s" % module, verbose)
 
             # Make a temp dir for this module (if doesn't exist)


### PR DESCRIPTION
JIRA: MADLIB-1078

Skip install-check for pmml when run without the '-t' option. We
can still run install-check for pmml if the '-t' option is
specified.

@iyerr3 