### PR TITLE
DT: Assign memory only for reachable nodes

### DIFF
--- a/src/modules/recursive_partitioning/DT_impl.hpp
+++ b/src/modules/recursive_partitioning/DT_impl.hpp
@@ -1136,7 +1136,7 @@ DecisionTree<Container>::displayLeafNode(
                     n_elem = NUM_PER_LINE;
                 } else {
                     // less than NUM_PER_LINE left, avoid reading past the end
-                    n_elem = pred_size - i;
+                    n_elem = static_cast<uint16_t>(pred_size - i);
                 }
                 display_str << predictions.row(id).segment(i, n_elem) << "\n";
             }
@@ -1180,7 +1180,7 @@ DecisionTree<Container>::displayInternalNode(
         size_t to_skip = 0;
         for (Index i=0; i < feature_indices(id); i++)
             to_skip += cat_n_levels[i];
-        const size_t index = to_skip + feature_thresholds(id);
+        const size_t index = to_skip + static_cast<size_t>(feature_thresholds(id));
         label_str << get_text(cat_levels_text, index);
     }
 
@@ -1206,7 +1206,7 @@ DecisionTree<Container>::displayInternalNode(
                     // not overflowing the vector
                     n_elem = NUM_PER_LINE;
                 } else {
-                    n_elem = pred_size - i;
+                    n_elem = static_cast<uint16_t>(pred_size - i);
                 }
                 display_str << predictions.row(id).segment(i, n_elem) << "\n";
             }

--- a/src/modules/recursive_partitioning/DT_impl.hpp
+++ b/src/modules/recursive_partitioning/DT_impl.hpp
@@ -475,17 +475,17 @@ DecisionTree<Container>::expand(const Accumulator &state,
                                 const uint16_t &min_split,
                                 const uint16_t &min_bucket,
                                 const uint16_t &max_depth) {
-    uint32_t n_non_leaf_nodes = static_cast<uint16_t>(state.n_leaf_nodes - 1);
+    uint32_t n_non_leaf_nodes = static_cast<uint32_t>(state.n_leaf_nodes - 1);
     bool children_not_allocated = true;
     bool children_wont_split = true;
 
     const uint16_t &sps = state.stats_per_split;  // short form for brevity
     for (Index i=0; i < state.n_leaf_nodes; i++) {
         Index current = n_non_leaf_nodes + i;
-        Index stats_i = static_cast<Index>(state.stats_lookup(i));
-        assert(stats_i >= 0);
-
         if (feature_indices(current) == IN_PROCESS_LEAF) {
+            Index stats_i = static_cast<Index>(state.stats_lookup(i));
+            assert(stats_i >= 0);
+
             // 1. Set the prediction for current node from stats of all rows
             predictions.row(current) = state.node_stats.row(stats_i);
 
@@ -550,7 +550,8 @@ DecisionTree<Container>::expand(const Accumulator &state,
                 }
                 children_wont_split &=
                     updatePrimarySplit(
-                        current, static_cast<int>(max_feat),
+                        current,
+                        static_cast<int>(max_feat),
                         max_threshold, max_is_cat,
                         min_split,
                         max_stats.segment(0, sps),   // true_stats

--- a/src/modules/recursive_partitioning/DT_impl.hpp
+++ b/src/modules/recursive_partitioning/DT_impl.hpp
@@ -475,7 +475,7 @@ DecisionTree<Container>::expand(const Accumulator &state,
                                 const uint16_t &min_split,
                                 const uint16_t &min_bucket,
                                 const uint16_t &max_depth) {
-    uint16_t n_non_leaf_nodes = static_cast<uint16_t>(state.n_leaf_nodes - 1);
+    uint32_t n_non_leaf_nodes = static_cast<uint16_t>(state.n_leaf_nodes - 1);
     bool children_not_allocated = true;
     bool children_wont_split = true;
 
@@ -637,8 +637,8 @@ DecisionTree<Container>::pickSurrogates(
     // Number of nodes in a last layer = 2^(tree_depth-1). (since depth starts from 1)
     // For n_surr_nodes, we need number of nodes in 2nd last layer,
     // so we use 2^(tree_depth-2)
-    uint16_t n_surr_nodes = static_cast<uint16_t>(pow(2, tree_depth - 2));
-    uint16_t n_ancestors = static_cast<uint16_t>(n_surr_nodes - 1);
+    uint32_t n_surr_nodes = static_cast<uint32_t>(pow(2, tree_depth - 2));
+    uint32_t n_ancestors = static_cast<uint32_t>(n_surr_nodes - 1);
 
     for (Index i=0; i < n_surr_nodes; i++){
         Index curr_node = n_ancestors + i;
@@ -744,7 +744,7 @@ DecisionTree<Container>::expand_by_sampling(const Accumulator &state,
                                 const uint16_t &max_depth,
                                 const int &n_random_features) {
 
-    uint16_t n_non_leaf_nodes = static_cast<uint16_t>(state.n_leaf_nodes - 1);
+    uint32_t n_non_leaf_nodes = static_cast<uint32_t>(state.n_leaf_nodes - 1);
     bool children_not_allocated = true;
     bool children_wont_split = true;
 
@@ -1072,7 +1072,7 @@ DecisionTree<Container>::recomputeTreeDepth() const{
         return tree_depth;
 
     for(uint16_t depth_counter = 2; depth_counter <= tree_depth; depth_counter++){
-        uint32_t n_leaf_nodes = static_cast<uint16_t>(pow(2, depth_counter - 1));
+        uint32_t n_leaf_nodes = static_cast<uint32_t>(pow(2, depth_counter - 1));
         uint32_t leaf_start_index = n_leaf_nodes - 1;
         bool all_non_existing = true;
         for (uint32_t leaf_index=0; leaf_index < n_leaf_nodes; leaf_index++){
@@ -1555,8 +1555,8 @@ TreeAccumulator<Container, DTree>::bind(ByteStream_type& inStream) {
     uint16_t n_cat = 0;
     uint16_t n_con = 0;
     uint32_t tot_levels = 0;
-    uint16_t n_leaves = 0;
-    uint16_t n_reachable_leaves = 0;
+    uint32_t n_leaves = 0;
+    uint32_t n_reachable_leaves = 0;
     uint16_t n_stats = 0;
 
     if (!n_rows.isNull()){
@@ -1590,7 +1590,7 @@ TreeAccumulator<Container, DTree>::rebind(
         uint16_t in_n_bins, uint16_t in_n_cat_feat,
         uint16_t in_n_con_feat, uint32_t in_n_total_levels,
         uint16_t tree_depth, uint16_t in_n_stats,
-        bool in_weights_as_rows, uint16_t n_reachable_leaves) {
+        bool in_weights_as_rows, uint32_t n_reachable_leaves) {
 
     n_bins = in_n_bins;
     n_cat_features = in_n_cat_feat;
@@ -1598,7 +1598,7 @@ TreeAccumulator<Container, DTree>::rebind(
     total_n_cat_levels = in_n_total_levels;
     weights_as_rows = in_weights_as_rows;
     if (tree_depth > 0)
-        n_leaf_nodes = static_cast<uint16_t>(pow(2, tree_depth - 1));
+        n_leaf_nodes = static_cast<uint32_t>(pow(2, tree_depth - 1));
     else
         n_leaf_nodes = 1;
     if (n_reachable_leaves >= n_leaf_nodes)
@@ -1638,7 +1638,7 @@ TreeAccumulator<Container, DTree>::operator<<(const tuple_type& inTuple) {
         } else if (n_con_features != static_cast<uint16_t>(con_features.size())) {
             warning("Inconsistent numbers of continuous independent variables.");
         } else{
-            uint16_t n_non_leaf_nodes = static_cast<uint16_t>(n_leaf_nodes - 1);
+            uint32_t n_non_leaf_nodes = static_cast<uint32_t>(n_leaf_nodes - 1);
             Index dt_search_index = dt.search(cat_features, con_features);
             if (dt.feature_indices(dt_search_index) != dt.FINISHED_LEAF &&
                    dt.feature_indices(dt_search_index) != dt.NODE_NON_EXISTING) {
@@ -1707,8 +1707,8 @@ TreeAccumulator<Container, DTree>::operator<<(const surr_tuple_type& inTuple) {
     } else{
         // the accumulator is setup to train for the 2nd last layer
         // hence the n_leaf_nodes is same as n_surr_nodes
-        uint16_t n_surr_nodes = n_leaf_nodes;
-        uint16_t n_non_surr_nodes = static_cast<uint16_t>(n_surr_nodes - 1);
+        uint32_t n_surr_nodes = n_leaf_nodes;
+        uint32_t n_non_surr_nodes = static_cast<uint32_t>(n_surr_nodes - 1);
 
         Index dt_parent_index = dt.parentIndex(dt.search(cat_features, con_features));
 

--- a/src/modules/recursive_partitioning/DT_proto.hpp
+++ b/src/modules/recursive_partitioning/DT_proto.hpp
@@ -246,7 +246,7 @@ public:
     void rebind(uint16_t n_bins, uint16_t n_cat_feat,
                 uint16_t n_con_feat, uint32_t n_total_levels,
                 uint16_t tree_depth, uint16_t n_stats, bool weights_as_rows,
-                uint16_t n_reachable_leaf_nodes);
+                uint32_t n_reachable_leaf_nodes);
 
     TreeAccumulator& operator<<(const tuple_type& inTuple);
     TreeAccumulator& operator<<(const surr_tuple_type& inTuple);
@@ -285,12 +285,12 @@ public:
     // sum of num of levels in each categorical variable
     uint32_type total_n_cat_levels;
     // n_leaf_nodes = 2^{dt.tree_depth-1} for dt.tree_depth > 0
-    uint16_type n_leaf_nodes;
+    uint32_type n_leaf_nodes;
 
     // Not all "leaf" nodes at a tree level are reachable. A leaf becomes
     // non-reachable when one of its ancestor is itself a leaf.
     // For a full tree, n_leaf_nodes = n_reachable_leaf_nodes
-    uint16_type n_reachable_leaf_nodes;
+    uint32_type n_reachable_leaf_nodes;
 
     // For regression, stats_per_split = 4, i.e. (w, w*y, w*y^2, 1)
     // For classification, stats_per_split = (number of class labels + 1)

--- a/src/modules/recursive_partitioning/DT_proto.hpp
+++ b/src/modules/recursive_partitioning/DT_proto.hpp
@@ -245,7 +245,8 @@ public:
     void bind(ByteStream_type& inStream);
     void rebind(uint16_t n_bins, uint16_t n_cat_feat,
                 uint16_t n_con_feat, uint32_t n_total_levels,
-                uint16_t tree_depth, uint16_t n_stats, bool weights_as_rows);
+                uint16_t tree_depth, uint16_t n_stats, bool weights_as_rows,
+                uint16_t n_reachable_leaf_nodes);
 
     TreeAccumulator& operator<<(const tuple_type& inTuple);
     TreeAccumulator& operator<<(const surr_tuple_type& inTuple);
@@ -327,10 +328,7 @@ public:
 
     // Above stats matrices are used as pseudo-sparse matrices since not all
     // leaf nodes are reachable (esp. as tree gets deeper).
-    // Each lookup vector is of size 'n_leaf_nodes'
-    IntegerVector_type cat_stats_lookup;
-    IntegerVector_type con_stats_lookup;
-    IntegerVector_type node_stats_lookup;
+    IntegerVector_type stats_lookup;
 };
 // ------------------------------------------------------------------------
 

--- a/src/modules/recursive_partitioning/DT_proto.hpp
+++ b/src/modules/recursive_partitioning/DT_proto.hpp
@@ -285,6 +285,12 @@ public:
     uint32_type total_n_cat_levels;
     // n_leaf_nodes = 2^{dt.tree_depth-1} for dt.tree_depth > 0
     uint16_type n_leaf_nodes;
+
+    // Not all "leaf" nodes at a tree level are reachable. A leaf becomes
+    // non-reachable when one of its ancestor is itself a leaf.
+    // For a full tree, n_leaf_nodes = n_reachable_leaf_nodes
+    uint16_type n_reachable_leaf_nodes;
+
     // For regression, stats_per_split = 4, i.e. (w, w*y, w*y^2, 1)
     // For classification, stats_per_split = (number of class labels + 1)
     // i.e. (w_1, w_2, ..., w_c, 1)
@@ -305,10 +311,11 @@ public:
     // con_stats and cat_stats are matrices that contain the statistics used
     // during training.
     // cat_stats is a matrix of size:
-    // (n_leaf_nodes) x (total_n_cat_levels * stats_per_split * 2)
+    // (n_reachable_leaf_nodes) x (total_n_cat_levels * stats_per_split * 2)
     Matrix_type cat_stats;
+
     // con_stats is a matrix:
-    // (n_leaf_nodes) x (n_con_features * n_bins * stats_per_split * 2)
+    // (n_reachable_leaf_nodes) x (n_con_features * n_bins * stats_per_split * 2)
     Matrix_type con_stats;
 
     // node_stats is used to keep a statistic of all the rows that land on a
@@ -317,6 +324,13 @@ public:
     // cat_stats/con_stats. In the presence of NULL value, the stats could be
     // different.
     Matrix_type node_stats;
+
+    // Above stats matrices are used as pseudo-sparse matrices since not all
+    // leaf nodes are reachable (esp. as tree gets deeper).
+    // Each lookup vector is of size 'n_leaf_nodes'
+    IntegerVector_type cat_stats_lookup;
+    IntegerVector_type con_stats_lookup;
+    IntegerVector_type node_stats_lookup;
 };
 // ------------------------------------------------------------------------
 

--- a/src/modules/recursive_partitioning/decision_tree.cpp
+++ b/src/modules/recursive_partitioning/decision_tree.cpp
@@ -154,7 +154,6 @@ compute_leaf_stats_transition::run(AnyType & args){
     }
 
     if (state.empty()){
-
         // To initialize the accumulator, first find which of the leaf nodes
         // in current tree are actually reachable.
         // The lookup vector maps the leaf node index in a (fictional) complete
@@ -162,7 +161,7 @@ compute_leaf_stats_transition::run(AnyType & args){
         ColumnVector leaf_feature_indices =
             dt.feature_indices.tail(dt.feature_indices.size()/2 + 1).cast<double>();
         ColumnVector leaf_node_lookup(leaf_feature_indices.size());
-        Index n_leaves_not_finished = 0;
+        size_t n_leaves_not_finished = 0;
         for (Index i=0; i < leaf_feature_indices.size(); i++){
             if ((leaf_feature_indices(i) != dt.NODE_NON_EXISTING) &&
                     (leaf_feature_indices(i) != dt.FINISHED_LEAF)){
@@ -187,7 +186,7 @@ compute_leaf_stats_transition::run(AnyType & args){
                      static_cast<uint16_t>(dt.tree_depth),
                      stats_per_split,
                      weights_as_rows,
-                     n_leaves_not_finished
+                     static_cast<uint32_t>(n_leaves_not_finished)
                     );
         for (Index i=0; i < state.stats_lookup.size(); i++)
             state.stats_lookup(i) = leaf_node_lookup(i);
@@ -265,8 +264,6 @@ dt_apply::run(AnyType & args){
             n_valid_nodes ++;
     }
 
-    elog(INFO, "Depth = %d, n_valid_nodes = %d",
-         static_cast<int>(dt.tree_depth), n_valid_nodes);
     AnyType output_tuple;
     output_tuple << dt.storage()
                  << return_code

--- a/src/modules/recursive_partitioning/decision_tree.cpp
+++ b/src/modules/recursive_partitioning/decision_tree.cpp
@@ -235,7 +235,14 @@ dt_apply::run(AnyType & args){
     else{
         return_code = TERMINATED;  // indicates termination due to error
     }
+    uint32_t n_valid_nodes = 0;
+    for (Index i=0; i < dt.feature_indices.size(); i++){
+        if (dt.feature_indices(i) != dt.NODE_NON_EXISTING)
+            n_valid_nodes ++;
+    }
 
+    elog(INFO, "Depth = %d, n_valid_nodes = %d",
+         static_cast<int>(dt.tree_depth), n_valid_nodes);
     AnyType output_tuple;
     output_tuple << dt.storage()
                  << return_code

--- a/src/modules/recursive_partitioning/decision_tree.cpp
+++ b/src/modules/recursive_partitioning/decision_tree.cpp
@@ -154,6 +154,25 @@ compute_leaf_stats_transition::run(AnyType & args){
     }
 
     if (state.empty()){
+
+        // To initialize the accumulator, first find which of the leaf nodes
+        // in current tree are actually reachable.
+        // The lookup vector maps the leaf node index in a (fictional) complete
+        // tree to the index in the actual tree.
+        ColumnVector leaf_feature_indices =
+            dt.feature_indices.tail(dt.feature_indices.size()/2 + 1).cast<double>();
+        ColumnVector leaf_node_lookup(leaf_feature_indices.size());
+        Index n_leaves_not_finished = 0;
+        for (Index i=0; i < leaf_feature_indices.size(); i++){
+            if ((leaf_feature_indices(i) != dt.NODE_NON_EXISTING) &&
+                    (leaf_feature_indices(i) != dt.FINISHED_LEAF)){
+                leaf_node_lookup(i) = n_leaves_not_finished++;  // increment after assigning
+            }
+            else{
+                leaf_node_lookup(i) = -1;
+            }
+        }
+
         // For classification, we store for each split the number of weighted
         // tuples for each possible response value and the number of unweighted
         // tuples landing on that node.
@@ -167,22 +186,27 @@ compute_leaf_stats_transition::run(AnyType & args){
                      static_cast<uint32_t>(cat_levels.sum()),
                      static_cast<uint16_t>(dt.tree_depth),
                      stats_per_split,
-                     weights_as_rows
+                     weights_as_rows,
+                     n_leaves_not_finished
                     );
+        for (Index i=0; i < state.stats_lookup.size(); i++)
+            state.stats_lookup(i) = leaf_node_lookup(i);
+
         // compute cumulative sum of the levels of the categorical variables
         int current_sum = 0;
         for (Index i=0; i < state.n_cat_features; ++i){
-            // We assume that the levels of each categorical variable are sorted
-            //  by the entropy for predicting the response. We then create splits
-            //  of the form 'A <= t', where A has N levels and t in [0, N-2].
+            // Assuming that the levels of each categorical variable are ordered,
+            //    create splits of the form 'A <= t', where A has N levels
+            //    and t in [0, N-2].
             // This split places all levels <= t on true node and
-            //  others on false node. We only check till N-2 since we want at
-            //  least 1 level falling to the false node.
-            // We keep a variable with just 1 level to ensure alignment,
-            //  even though that variable will not be used as a split feature.
+            //    others on false node. Checking till N-2 instead of N-1
+            //    since at least 1 level should go to false node.
+            // Variable with just 1 level is maintained to ensure alignment,
+            //    even though the variable will not be used as a split feature.
             current_sum += cat_levels(i);
             state.cat_levels_cumsum(i) = current_sum;
         }
+
     }
 
     state << MutableLevelState::tuple_type(dt, cat_features, con_features,
@@ -299,6 +323,21 @@ compute_surr_stats_transition::run(AnyType & args){
     // the root be an internal node i.e. we need the tree_depth to be more than 1.
     if (dt.tree_depth > 1){
         if (state.empty()){
+             // To initialize the accumulator, first find which of the last
+             // level of internal nodes are actually reachable.
+            ColumnVector final_internal_feature_indices =
+                dt.feature_indices.segment(dt.feature_indices.size()/4,
+                                           dt.feature_indices.size()/4 + 1).cast<double>();
+            ColumnVector index_lookup(final_internal_feature_indices.size());
+            Index n_internal_nodes_reachable = 0;
+            for (Index i=0; i < final_internal_feature_indices.size(); i++){
+                if (final_internal_feature_indices(i) >= 0){
+                    index_lookup(i) = n_internal_nodes_reachable++;  // increment after assigning
+                }
+                else{
+                    index_lookup(i) = -1;
+                }
+            }
             // 1. We need to compute stats for parent of each leaf.
             //      Hence the tree_depth is decremented by 1.
             // 2. We store 2 values for each surrogate split
@@ -310,8 +349,11 @@ compute_surr_stats_transition::run(AnyType & args){
                          static_cast<uint32_t>(cat_levels.sum()),
                          static_cast<uint16_t>(dt.tree_depth - 1),
                          2,
-                         false // dummy, only used in compute_leaf_stat
+                         false, // dummy, only used in compute_leaf_stat
+                         n_internal_nodes_reachable
                         );
+            for (Index i = 0; i < state.stats_lookup.size(); ++i)
+                state.stats_lookup(i) = index_lookup(i);
             // compute cumulative sum of the levels of the categorical variables
             int current_sum = 0;
             for (Index i=0; i < state.n_cat_features; ++i){

--- a/src/modules/recursive_partitioning/decision_tree.cpp
+++ b/src/modules/recursive_partitioning/decision_tree.cpp
@@ -259,15 +259,6 @@ dt_apply::run(AnyType & args){
         return_code = TERMINATED;  // indicates termination due to error
     }
 
-    // DEBUG
-    uint32_t n_valid_nodes = 0;
-    for (Index i=0; i < dt.feature_indices.size(); i++){
-        if (dt.feature_indices(i) != dt.NODE_NON_EXISTING)
-            n_valid_nodes ++;
-    }
-    elog(INFO, "Depth = %d, n_valid_nodes = %d",
-         static_cast<int>(dt.tree_depth), n_valid_nodes);
-    // DEBUG
 
     AnyType output_tuple;
     output_tuple << dt.storage()

--- a/src/modules/recursive_partitioning/decision_tree.cpp
+++ b/src/modules/recursive_partitioning/decision_tree.cpp
@@ -258,11 +258,16 @@ dt_apply::run(AnyType & args){
     else{
         return_code = TERMINATED;  // indicates termination due to error
     }
+
+    // DEBUG
     uint32_t n_valid_nodes = 0;
     for (Index i=0; i < dt.feature_indices.size(); i++){
         if (dt.feature_indices(i) != dt.NODE_NON_EXISTING)
             n_valid_nodes ++;
     }
+    elog(INFO, "Depth = %d, n_valid_nodes = %d",
+         static_cast<int>(dt.tree_depth), n_valid_nodes);
+    // DEBUG
 
     AnyType output_tuple;
     output_tuple << dt.storage()


### PR DESCRIPTION
JIRA: MADLIB-1057

TreeAccumulator assigns a matrix to track the statistics of rows
reaching the last layer of nodes. This matrix assumes a complete 
tree and assigns memory for all nodes. As the tree gets deeper, 
most of the nodes are unreachable, resulting in excessive wasted
memory. This commit reduces that waste by only assigning memory
for nodes that are reachable and accessing them through a lookup 
table.