### PR TITLE
MADLIB-1138. Add basic code coverage support:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,7 @@ list(APPEND CMAKE_MODULE_PATH
 include(Utils)
 include(LinuxUtils)
 include(OSXUtils)
+include(Options)
 
 
 # -- Include all parts ---------------------------------------------------------

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -1,0 +1,61 @@
+# ======================================================================
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ======================================================================
+
+# ----------------------------------------------------------------------
+# Check for code coverage utilities
+# ----------------------------------------------------------------------
+
+find_program(LCOV_PATH lcov
+  DOC "Path to the lcov utility."
+  )
+
+if(NOT LCOV_PATH)
+  message(FATAL_ERROR "lcov not found!")
+endif(NOT LCOV_PATH)
+
+find_program(GENHTML_PATH genhtml
+  DOC "Path to the genhtml utility."
+  )
+
+if(NOT GENHTML_PATH)
+  message(FATAL_ERROR "genhtml not found!")
+endif(NOT GENHTML_PATH)
+
+# ----------------------------------------------------------------------
+# Setup code coverage compilation/link options
+# ----------------------------------------------------------------------
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage")
+
+set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
+
+# ----------------------------------------------------------------------
+# Custom code coverage targets
+# ----------------------------------------------------------------------
+
+add_custom_target(GenCoverageReport
+  # Capture gcov counters and generate report
+  COMMAND ${LCOV_PATH} --directory . --capture --output-file CodeCoverage.info
+  COMMAND ${LCOV_PATH} --remove CodeCoverage.info '/usr/include/*' '/usr/local/*' '*build/third_party/*' --output-file CodeCoverage-filtered.info
+  COMMAND ${GENHTML_PATH} --title="MADlib" --legend --function-coverage --output-directory CodeCoverageReport CodeCoverage-filtered.info
+  )
+
+add_custom_target(ResetCoverageCounters
+  # Zero gcov counters
+  COMMAND ${LCOV_PATH} --directory . --zerocounters
+)

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -1,0 +1,22 @@
+# ======================================================================
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ======================================================================
+
+OPTION(ENABLE_COVERAGE "Enable code coverage" OFF)
+
+IF(ENABLE_COVERAGE STREQUAL ON)
+  INCLUDE(CodeCoverage)
+ENDIF(ENABLE_COVERAGE STREQUAL ON)


### PR DESCRIPTION
For developers, add cmake option configuration option ENABLE_COVERAGE
which will introduce gcov compilation and linking
options (-fprofile-arcs -ftest-coverage). Two supporting make targets
are introduced:

 * GenCoverageReport - Capture gcov counters and generate report
 * ResetCoverageCounters - Zero counters gcov counters

Features:

* Counters will be captured in build/CodeCoverage.info file. System
  and Third party metrics will be filtered out of coverage info file
  and stored in CodeCoverage-filtered.info
* HTML report will be created in build/CodeCoverageReport directory

Usage:
* cmake -DENABLE_COVERAGE=ON ..
* <build, install and execute desired tests as usual>
* make GenCoverageReport
* ... To view report, open build/CodeCoverageReport/index.html in browser ...
* make ResetCoverageCounters
*  ... Run another test ...
* make GenCoverageReport