### PR TITLE
Bugfix: Handle WCC output table error case

### DIFF
--- a/src/ports/postgres/modules/graph/wcc.py_in
+++ b/src/ports/postgres/modules/graph/wcc.py_in
@@ -100,8 +100,10 @@ def wcc(schema_madlib, vertex_table, vertex_id, edge_table, edge_args,
         v_st = vertex_id
     if not grouping_cols:
         grouping_cols = ''
-    out_table_summary = add_postfix(out_table, "_summary")
 
+    out_table_summary = ''
+    if out_table:
+        out_table_summary = add_postfix(out_table, "_summary")
     grouping_cols_list = split_quoted_delimited_str(grouping_cols)
     validate_wcc_args(schema_madlib, vertex_table, vertex_id, edge_table,
                       edge_params, out_table, out_table_summary,


### PR DESCRIPTION
If the output table name is NULL, the code doesn't catch and error
out, but errors out because python cannot call strip() function on
NULL. This commit fixes that input parameter (for output table name)
error case scenario.

Closes #160