### PR TITLE
MADLIB-1118. Change tolerance to 1e-2 (from 1e-6)

### DIFF
--- a/src/ports/postgres/modules/elastic_net/test/elastic_net_install_check.sql_in
+++ b/src/ports/postgres/modules/elastic_net/test/elastic_net_install_check.sql_in
@@ -562,7 +562,7 @@ begin
    }    1',
         NULL,
         2000,
-        1e-6
+        1e-2
     );
 
     -- PERFORM assert(relative_error(log_likelihood, -14.41122) < 1e-3,
@@ -598,7 +598,7 @@ begin
    }    1',
         NULL,
         2000,
-        1e-6
+        1e-2
     );
 
     -- PERFORM assert(((relative_error(log_likelihood, -16.43510) < 1e-3 or
@@ -635,7 +635,7 @@ begin
    }    1',
         NULL,
         2000,
-        1e-6
+        1e-2
     );
 
     EXECUTE 'DROP TABLE IF EXISTS house_en_pred';
@@ -667,7 +667,7 @@ begin
    }    1',
         NULL,
         2000,
-        1e-6
+        1e-2
     );
 
     -- PERFORM assert(((relative_error(log_likelihood, -17.42548) < 1e-3 or
@@ -702,7 +702,7 @@ begin
         'eta = 2, max_stepsize = 0.5, use_active_set = f, random_stepsize = t',
         NULL,
         20000,
-        1e-6
+        1e-2
     );
 
     -- PERFORM assert(relative_error(log_likelihood, -0.542468) < 1e-3,
@@ -737,7 +737,7 @@ begin
         'eta = 2, max_stepsize = 0.5, use_active_set = t, activeset_tolerance = 1e-6, random_stepsize = t',
         NULL,
         20000,
-        1e-6
+        1e-2
     );
 
     -- PERFORM assert(((relative_error(log_likelihood, -0.61782) < 1e-3 or
@@ -773,7 +773,7 @@ begin
         'stepsize = 1',
         NULL,
         20000,
-        1e-6
+        1e-2
     );
 
     -- PERFORM assert(((relative_error(log_likelihood, -0.84930) < 1e-3 or
@@ -807,7 +807,7 @@ begin
         '',
         '',
         10000,
-        1e-6
+        1e-2
     );
 
 end;
@@ -835,7 +835,7 @@ SELECT elastic_net_train(
     $$,
     NULL,
     100,
-    1e-6
+    1e-2
 );
 SELECT * FROM house_en;
 SELECT * FROM house_en_summary;
@@ -861,7 +861,7 @@ SELECT * FROM house_en_summary;
 --     $$,
 --     NULL,
 --     100,
---     1e-6
+--     1e-2
 -- );
 -- SELECT * FROM house_en;
 -- SELECT * FROM house_en_summary;


### PR DESCRIPTION
This changes the execution elapsed time to 2252 milliseconds from
10171 milliseconds on mac with Postgre 9.6