### PR TITLE
Measures: Use outer join for in-out degrees computation

### DIFF
--- a/src/ports/postgres/modules/graph/measures.py_in
+++ b/src/ports/postgres/modules/graph/measures.py_in
@@ -215,8 +215,8 @@ class Graph(object):
             SELECT
                 {grouping_cols_comma}
                 in_q.vertex as {self.vertex_id_col},
-                indegree,
-                outdegree
+                coalesce(indegree, 0) as indegree,
+                coalesce(outdegree, 0) as outdegree
             FROM
             (
                 SELECT
@@ -224,18 +224,22 @@ class Graph(object):
                     {e.dest} as vertex,
                     count(*) as indegree
                 FROM {self.edge_table}
-                WHERE {e.src} != {e.dest}
+                WHERE {e.src} != {e.dest} AND
+                      {e.src} IS NOT NULL AND
+                      {e.dest} IS NOT NULL
                 GROUP BY {grouping_cols_comma}
                          {e.dest}
             ) as in_q
-            JOIN
+            FULL OUTER JOIN
             (
                 SELECT
                     {grouping_cols_comma}
                     {e.src} as vertex,
                     count(*) as outdegree
                 FROM {self.edge_table}
-                WHERE {e.src} != {e.dest}
+                WHERE {e.src} != {e.dest} AND
+                      {e.src} IS NOT NULL AND
+                      {e.dest} IS NOT NULL
                 GROUP BY {grouping_cols_comma}
                          {e.src}
             ) as out_q

--- a/src/ports/postgres/modules/graph/measures.sql_in
+++ b/src/ports/postgres/modules/graph/measures.sql_in
@@ -734,7 +734,7 @@ SELECT * FROM degrees ORDER BY id;
   4 |        1 |         1
   5 |        1 |         1
   6 |        2 |         1
-(7 rows)
+  7 |        1 |         0
 </pre>
 
 -# Create a graph with 2 groups and find degrees for each group:


### PR DESCRIPTION
JIRA: MADLIB-1073

Commit 06788cc added the graph measure functions described in the JIRA.
This commit fixes a bug from that commit in the graph_vertex_degrees
function. The bug led to results not containing vertices that
either had 0 in-degree or out-degree.